### PR TITLE
chore: release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project does not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) until v1.0.0.
 
+## [1.0.3](https://github.com/oxc-project/oxc-sourcemap/compare/v1.0.2...v1.0.3) - 2024-12-03
+
+### Other
+
+- rename feature `concurrent` to `rayon`
+
 ## [1.0.2](https://github.com/oxc-project/oxc-sourcemap/compare/v1.0.1...v1.0.2) - 2024-12-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
 
 [[package]]
 name = "oxc_sourcemap"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "base64-simd",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_sourcemap"
-version = "1.0.2"
+version = "1.0.3"
 publish = true
 authors = ["Boshen <boshenc@gmail.com>"]
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `oxc_sourcemap`: 1.0.2 -> 1.0.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.3](https://github.com/oxc-project/oxc-sourcemap/compare/v1.0.2...v1.0.3) - 2024-12-03

### Other

- rename feature `concurrent` to `rayon`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).