### PR TITLE
fix(lookup_token): should be None if original tokens hasn't the line

### DIFF
--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -187,7 +187,9 @@ impl SourceMap {
         if line >= lookup_table.len() as u32 {
             return None;
         }
-        let table = greatest_lower_bound(&lookup_table[line as usize], &(line, col), |table| (table.0, table.1))?;
+        let table = greatest_lower_bound(&lookup_table[line as usize], &(line, col), |table| {
+            (table.0, table.1)
+        })?;
         self.get_token(table.2)
     }
 
@@ -261,9 +263,7 @@ fn test_sourcemap_lookup_token() {
         (Some("coolstuff.js"), 2, 8, None)
     );
 
-    assert!(
-        sm.lookup_source_view_token(&lookup_table, 1000, 0).is_none()
-    );
+    assert!(sm.lookup_source_view_token(&lookup_table, 1000, 0).is_none());
 }
 
 #[test]

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -166,7 +166,7 @@ impl SourceMap {
     pub fn generate_lookup_table(&self) -> Vec<LineLookupTable> {
         // The dst line/dst col always has increasing order.
         if let Some(last_token) = self.tokens.last() {
-            let mut table: Vec<Vec<(u32, u32, u32)>> = vec![vec![]; last_token.dst_line as usize + 1];
+            let mut table = vec![vec![]; last_token.dst_line as usize + 1];
             for (idx, token) in self.tokens.iter().enumerate() {
                 table[token.dst_line as usize].push((token.dst_line, token.dst_col, idx as u32));
             }

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -164,18 +164,13 @@ impl SourceMap {
 
     /// Generate a lookup table, it will be used at `lookup_token` or `lookup_source_view_token`.
     pub fn generate_lookup_table(&self) -> Vec<LineLookupTable> {
-        let mut tokens = self
-            .tokens
-            .iter()
-            .enumerate()
-            .map(|(idx, token)| (token.dst_line, token.dst_col, idx as u32))
-            .collect::<Vec<_>>();
-        tokens.sort_unstable();
-        if let Some(last_token) = tokens.last() {
-            let mut table: Vec<Vec<(u32, u32, u32)>> = vec![vec![]; last_token.0 as usize + 1];
-            for token in tokens.into_iter() {
-                table[token.0 as usize].push(token);
+        // The dst line/dst col always has increasing order.
+        if let Some(last_token) = self.tokens.last() {
+            let mut table: Vec<Vec<(u32, u32, u32)>> = vec![vec![]; last_token.dst_line as usize + 1];
+            for (idx, token) in self.tokens.iter().enumerate() {
+                table[token.dst_line as usize].push((token.dst_line, token.dst_col, idx as u32));
             }
+            table.iter_mut().for_each(|line| line.sort_unstable());
             table
         } else {
             vec![]

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -164,12 +164,18 @@ impl SourceMap {
 
     /// Generate a lookup table, it will be used at `lookup_token` or `lookup_source_view_token`.
     pub fn generate_lookup_table(&self) -> Vec<LineLookupTable> {
-        if let Some(token) = self.tokens.last() {
-            let mut table: Vec<Vec<(u32, u32, u32)>> = vec![vec![]; token.dst_line as usize + 1];
-            for (idx, token) in self.tokens.iter().enumerate() {
-                table[token.dst_line as usize].push((token.dst_line, token.dst_col, idx as u32));
+        let mut tokens = self
+            .tokens
+            .iter()
+            .enumerate()
+            .map(|(idx, token)| (token.dst_line, token.dst_col, idx as u32))
+            .collect::<Vec<_>>();
+        tokens.sort_unstable();
+        if let Some(last_token) = tokens.last() {
+            let mut table: Vec<Vec<(u32, u32, u32)>> = vec![vec![]; last_token.0 as usize + 1];
+            for token in tokens.into_iter() {
+                table[token.0 as usize].push(token);
             }
-            table.iter_mut().for_each(|line| line.sort_unstable());
             table
         } else {
             vec![]


### PR DESCRIPTION
close https://github.com/rolldown/rolldown/issues/3112. 

You could see the pervious test `(1000, 0)` return `(2, 8)`, it is last token at original mapping, if we add more token exceeding the line, it will always mapping to the last token, it is incorrect.

The pr fixed it. Here create `Vec<LineLookupTable>` for original tokens, if is easy to check exceeding line, and also has better performance  than the previous implement, it only binarySearch the line tokens instead of the all tokens. It  inspire from https://github.com/jridgewell/trace-mapping/blob/main/src/trace-mapping.ts#L178