### PR TITLE
fix: handle non existing token position in visualizer

### DIFF
--- a/src/sourcemap_visualizer.rs
+++ b/src/sourcemap_visualizer.rs
@@ -34,7 +34,9 @@ impl<'a> SourcemapVisualizer<'a> {
         let mut last_source: Option<&str> = None;
         for i in 0..tokens.len() {
             let t = &tokens[i];
-            let Some(source_id) = t.source_id else { continue; };
+            let Some(source_id) = t.source_id else {
+                continue;
+            };
             let Some(source) = self.sourcemap.get_source(source_id) else { continue };
             let source_lines = &source_contents_lines_map[source_id as usize];
 
@@ -48,8 +50,10 @@ impl<'a> SourcemapVisualizer<'a> {
             }
 
             // validate token position
-            let dst_invalid = t.dst_line as usize >= output_lines.len() || (t.dst_col as usize) >= output_lines[t.dst_line as usize].len();
-            let src_invalid = t.src_line as usize >= source_lines.len() || (t.src_col as usize) >= source_lines[t.src_line as usize].len();
+            let dst_invalid = t.dst_line as usize >= output_lines.len()
+                || (t.dst_col as usize) >= output_lines[t.dst_line as usize].len();
+            let src_invalid = t.src_line as usize >= source_lines.len()
+                || (t.src_col as usize) >= source_lines[t.src_line as usize].len();
             if dst_invalid || src_invalid {
                 s.push_str(&format!(
                     "({}:{}){} --> ({}:{}){}\n",
@@ -120,17 +124,14 @@ impl<'a> SourcemapVisualizer<'a> {
         tables
     }
 
-    fn str_slice_by_token(
-        buff: &[Vec<u16>],
-        line: u32,
-        col_start: u32,
-        col_end: u32,
-    ) -> Cow<'_, str> {
-        String::from_utf16(
-            &buff[line as usize][col_start.min(col_end) as usize..col_start.max(col_end) as usize],
-        )
-        .unwrap()
-        .replace("\r", "")
-        .into()
+    fn str_slice_by_token(buff: &[Vec<u16>], line: u32, start: u32, end: u32) -> Cow<'_, str> {
+        let line = line as usize;
+        let start = start as usize;
+        let end = end as usize;
+        let s = &buff[line];
+        String::from_utf16(&s[start.min(end).min(s.len())..start.max(end).min(s.len())])
+            .unwrap()
+            .replace("\r", "")
+            .into()
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -25,7 +25,9 @@ fn invalid_token_position() {
         vec!["src.js".into()],
         Some(vec!["abc\ndef".into()]),
         vec![
-            Token::new(0, 10, 10, 0, Some(0), None),
+            Token::new(0, 0, 0, 0, Some(0), None),
+            Token::new(0, 10, 0, 0, Some(0), None),
+            Token::new(0, 0, 0, 10, Some(0), None),
         ],
         None,
     );

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use oxc_sourcemap::{SourceMap, SourcemapVisualizer};
+use oxc_sourcemap::{SourceMap, SourcemapVisualizer, Token};
 
 #[test]
 fn snapshot_sourcemap_visualizer() {
@@ -14,4 +14,23 @@ fn snapshot_sourcemap_visualizer() {
             insta::assert_snapshot!("visualizer", visualizer_text);
         });
     });
+}
+
+#[test]
+fn invalid_token_position() {
+    let sourcemap = SourceMap::new(
+        None,
+        vec![],
+        None,
+        vec!["src.js".into()],
+        Some(vec!["abc\ndef".into()]),
+        vec![
+            Token::new(0, 10, 10, 0, Some(0), None),
+        ],
+        None,
+    );
+    let js = "abc\ndef\n";
+    let visualizer = SourcemapVisualizer::new(js, &sourcemap);
+    let visualizer_text = visualizer.into_visualizer_text();
+    insta::assert_snapshot!("invalid_token_position", visualizer_text);
 }

--- a/tests/snapshots/main__invalid_token_position.snap
+++ b/tests/snapshots/main__invalid_token_position.snap
@@ -1,0 +1,7 @@
+---
+source: tests/main.rs
+expression: visualizer_text
+snapshot_kind: text
+---
+- src.js
+(10:0) [invalid] --> (0:10) [invalid]

--- a/tests/snapshots/main__invalid_token_position.snap
+++ b/tests/snapshots/main__invalid_token_position.snap
@@ -4,4 +4,6 @@ expression: visualizer_text
 snapshot_kind: text
 ---
 - src.js
-(10:0) [invalid] --> (0:10) [invalid]
+(0:0) "abc\n" --> (0:0) "abc\n"
+(0:0) --> (0:10) [invalid]
+(0:10) [invalid] --> (0:0)


### PR DESCRIPTION
Currently it panics as out-of-bound index, so I fixed it with a visible warning in visualizer. I was reading source-map-validator (cf. https://github.com/oxc-project/oxc-sourcemap/issues/11) and it looks like they validate token position too https://github.com/jkup/source-map-validator/blob/183339fa5cb10f374587552251ed88064f26bfde/src/validators/SourceMapMappingsValidator.ts#L34-L41