### PR TITLE
fix: `sources_content` should be `Vec<Option<Arc<str>>>`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -39,9 +39,10 @@ pub fn decode(json: JSONSourceMap) -> Result<SourceMap> {
         names: json.names.into_iter().map(Arc::from).collect(),
         source_root: json.source_root,
         sources: json.sources.into_iter().map(Arc::from).collect(),
-        source_contents: json.sources_content.map(|content| {
-            content.into_iter().map(|c| c.map(Arc::from).unwrap_or_default()).collect()
-        }),
+        source_contents: json
+            .sources_content
+            .map(|content| content.into_iter().map(|c| c.map(Arc::from)).collect())
+            .unwrap_or_default(),
         tokens,
         token_chunks: None,
         x_google_ignore_list: json.x_google_ignore_list,

--- a/src/sourcemap_builder.rs
+++ b/src/sourcemap_builder.rs
@@ -15,7 +15,7 @@ pub struct SourceMapBuilder {
     pub(crate) names: Vec<Arc<str>>,
     pub(crate) sources: Vec<Arc<str>>,
     pub(crate) sources_map: FxHashMap<Arc<str>, u32>,
-    pub(crate) source_contents: Vec<Arc<str>>,
+    pub(crate) source_contents: Vec<Option<Arc<str>>>,
     pub(crate) tokens: Vec<Token>,
     pub(crate) token_chunks: Option<Vec<TokenChunk>>,
 }
@@ -38,7 +38,7 @@ impl SourceMapBuilder {
         let id = *self.sources_map.entry(source.into()).or_insert(count);
         if id == count {
             self.sources.push(source.into());
-            self.source_contents.push(source_content.into());
+            self.source_contents.push(Some(source_content.into()));
         }
         id
     }
@@ -48,7 +48,7 @@ impl SourceMapBuilder {
     pub fn set_source_and_content(&mut self, source: &str, source_content: &str) -> u32 {
         let count = self.sources.len() as u32;
         self.sources.push(source.into());
-        self.source_contents.push(source_content.into());
+        self.source_contents.push(Some(source_content.into()));
         count
     }
 
@@ -80,7 +80,7 @@ impl SourceMapBuilder {
             self.names,
             None,
             self.sources,
-            Some(self.source_contents),
+            self.source_contents,
             self.tokens,
             self.token_chunks,
         )

--- a/src/sourcemap_visualizer.rs
+++ b/src/sourcemap_visualizer.rs
@@ -16,15 +16,18 @@ impl<'a> SourcemapVisualizer<'a> {
 
     pub fn into_visualizer_text(self) -> String {
         let mut s = String::new();
-
-        let Some(source_contents) = &self.sourcemap.source_contents else {
+        let source_contents = &self.sourcemap.source_contents;
+        if self.sourcemap.source_contents.is_empty() {
             s.push_str("[no source contents]\n");
             return s;
-        };
+        }
 
         let source_contents_lines_map: Vec<Vec<Vec<u16>>> = source_contents
             .iter()
-            .map(|content| Self::generate_line_utf16_tables(content))
+            .filter_map(|content| {
+                let content = content.as_ref()?;
+                Some(Self::generate_line_utf16_tables(content))
+            })
             .collect();
 
         let output_lines = Self::generate_line_utf16_tables(self.output);

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -23,7 +23,7 @@ fn invalid_token_position() {
         vec![],
         None,
         vec!["src.js".into()],
-        Some(vec!["abc\ndef".into()]),
+        vec![Some("abc\ndef".into())],
         vec![
             Token::new(0, 0, 0, 0, Some(0), None),
             Token::new(0, 10, 0, 0, Some(0), None),


### PR DESCRIPTION
1. related to https://github.com/rolldown/rolldown/issues/4327
2. Rollup `sourcemap.sources_content` type is `null | string`, however it is `Arc<str>` in **oxc_sourcemap**, 
see also 
https://github.com/rollup/rollup/blob/061a0387c8654222620f602471d66afd3c582048/src/utils/collapseSourcemaps.ts?plain=1#L197
https://github.com/getsentry/rust-sourcemap/blob/master/src/types.rs#L468
https://github.com/getsentry/rust-sourcemap/blob/f946f5a581c598c8a89dfd076eb39d5867ba3955/src/builder.rs#L30