### PR TITLE
docs: remove outdated text from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@
 
 # oxc-sourcemap
 
-Forked version of [rust-sourcemap](https://github.com/getsentry/rust-sourcemap), but has some different with it.
-
-- Avoid `Sourcemap` some methods overhead, like `SourceMap::tokens()`.
+Forked version of [rust-sourcemap](https://github.com/getsentry/rust-sourcemap), modified for Oxc.
 
 [discord-badge]: https://img.shields.io/discord/1079625926024900739?logo=discord&label=Discord
 [discord-url]: https://discord.gg/9uXCAwqQZW

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 
 Forked version of [rust-sourcemap](https://github.com/getsentry/rust-sourcemap), but has some different with it.
 
-- Encode sourcemap at parallel, including quote `sourceContent` and encode token to `vlq` mappings.
 - Avoid `Sourcemap` some methods overhead, like `SourceMap::tokens()`.
 
 [discord-badge]: https://img.shields.io/discord/1079625926024900739?logo=discord&label=Discord


### PR DESCRIPTION
Update docs to reflect recent changes. #81 removed parallel sourcemap encoding.