### PR TITLE
perf: use simd optimzed json string escape impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-escape-simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc1cc6a0d3d3e002739c6c2bef8944614100173c4a5c1af0c2e5ee36bf3b5a3"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +471,7 @@ dependencies = [
  "base64-simd",
  "criterion2",
  "insta",
+ "json-escape-simd",
  "napi",
  "napi-build",
  "napi-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ ignored = ["napi"]
 
 [dependencies]
 base64-simd = "0.8"
+json-escape-simd = "1"
 napi = { version = "3", optional = true }
 napi-derive = { version = "3", optional = true }
 rustc-hash = "2"

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -2,6 +2,8 @@
 
 use std::borrow::Cow;
 
+use json_escape_simd::{escape as escape_json_string, escape_generic};
+
 use crate::JSONSourceMap;
 use crate::{SourceMap, Token, token::TokenChunk};
 
@@ -23,8 +25,8 @@ pub fn encode(sourcemap: &SourceMap) -> JSONSourceMap {
         x_google_ignore_list: sourcemap.get_x_google_ignore_list().map(|x| x.to_vec()),
     }
 }
-fn escape_optional_json_string<S: AsRef<str>>(s: &Option<S>) -> String {
-    s.as_ref().map(escape_json_string).unwrap_or_else(|| String::from("null"))
+fn escape_optional_json_string<'s, S: AsRef<str>>(s: &'s Option<S>) -> Cow<'s, str> {
+    s.as_ref().map(escape_json_string).map(Cow::Owned).unwrap_or_else(|| Cow::Borrowed("null"))
 }
 
 pub fn encode_to_string(sourcemap: &SourceMap) -> String {
@@ -50,10 +52,10 @@ pub fn encode_to_string(sourcemap: &SourceMap) -> String {
     }
 
     contents.push("\"names\":[".into());
-    contents.push_list(sourcemap.names.iter().map(escape_json_string));
+    contents.push_list(sourcemap.names.iter().map(|s| Cow::Owned(escape_generic(s))));
 
     contents.push("],\"sources\":[".into());
-    contents.push_list(sourcemap.sources.iter().map(escape_json_string));
+    contents.push_list(sourcemap.sources.iter().map(|s| Cow::Owned(escape_generic(s))));
 
     // Quote `source_content` in parallel
     let source_contents = &sourcemap.source_contents;
@@ -62,7 +64,7 @@ pub fn encode_to_string(sourcemap: &SourceMap) -> String {
 
     if let Some(x_google_ignore_list) = &sourcemap.x_google_ignore_list {
         contents.push("],\"x_google_ignoreList\":[".into());
-        contents.push_list(x_google_ignore_list.iter().map(ToString::to_string));
+        contents.push_list(x_google_ignore_list.iter().map(|s| Cow::Owned(s.to_string())));
     }
 
     contents.push("],\"mappings\":\"".into());
@@ -301,16 +303,16 @@ impl<'a> PreAllocatedString<'a> {
     #[inline]
     fn push_list<I>(&mut self, mut iter: I)
     where
-        I: Iterator<Item = String>,
+        I: Iterator<Item = Cow<'a, str>>,
     {
         let Some(first) = iter.next() else {
             return;
         };
-        self.push(Cow::Owned(first));
+        self.push(first);
 
         for other in iter {
             self.push(Cow::Borrowed(","));
-            self.push(Cow::Owned(other));
+            self.push(other);
         }
     }
 
@@ -325,137 +327,6 @@ impl<'a> PreAllocatedString<'a> {
         self.buf.len()
     }
 }
-
-// Slightly modified version of
-// <https://github.com/serde-rs/json/blob/d12e943590208da738c092db92c34b39796a2538/src/ser.rs#L2079>
-fn escape_json_string<S: AsRef<str>>(s: S) -> String {
-    let s = s.as_ref();
-    let bytes = s.as_bytes();
-
-    // Estimate capacity - most strings don't need much escaping
-    // Add some padding for potential escapes
-    let estimated_capacity = bytes.len() + bytes.len() / 2 + 2;
-    let mut result = Vec::with_capacity(estimated_capacity);
-
-    result.push(b'"');
-
-    let mut start = 0;
-    let mut i = 0;
-
-    while i < bytes.len() {
-        let b = bytes[i];
-
-        // Use lookup table to check if escaping is needed
-        let escape_byte = ESCAPE[b as usize];
-
-        if escape_byte == 0 {
-            // No escape needed, continue scanning
-            i += 1;
-            continue;
-        }
-
-        // Copy any unescaped bytes before this position
-        if start < i {
-            result.extend_from_slice(&bytes[start..i]);
-        }
-
-        // Handle the escape
-        result.push(b'\\');
-        if escape_byte == b'u' {
-            // Unicode escape for control characters
-            result.extend_from_slice(b"u00");
-            let hex_digits = &HEX_BYTES[b as usize];
-            result.push(hex_digits.0);
-            result.push(hex_digits.1);
-        } else {
-            // Simple escape
-            result.push(escape_byte);
-        }
-
-        i += 1;
-        start = i;
-    }
-
-    // Copy any remaining unescaped bytes
-    if start < bytes.len() {
-        result.extend_from_slice(&bytes[start..]);
-    }
-
-    result.push(b'"');
-
-    // SAFETY: We only pushed valid UTF-8 bytes (original string bytes and ASCII escape sequences)
-    unsafe { String::from_utf8_unchecked(result) }
-}
-
-const BB: u8 = b'b'; // \x08
-const TT: u8 = b't'; // \x09
-const NN: u8 = b'n'; // \x0A
-const FF: u8 = b'f'; // \x0C
-const RR: u8 = b'r'; // \x0D
-const QU: u8 = b'"'; // \x22
-const BS: u8 = b'\\'; // \x5C
-const UU: u8 = b'u'; // \x00...\x1F except the ones above
-const __: u8 = 0;
-
-// Lookup table of escape sequences. A value of b'x' at index i means that byte
-// i is escaped as "\x" in JSON. A value of 0 means that byte i is not escaped.
-static ESCAPE: [u8; 256] = [
-    //   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
-    UU, UU, UU, UU, UU, UU, UU, UU, BB, TT, NN, UU, FF, RR, UU, UU, // 0
-    UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, // 1
-    __, __, QU, __, __, __, __, __, __, __, __, __, __, __, __, __, // 2
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 3
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 4
-    __, __, __, __, __, __, __, __, __, __, __, __, BS, __, __, __, // 5
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 6
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 7
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 8
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 9
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // A
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // B
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // C
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // D
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // E
-    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
-];
-
-// Pre-computed hex digit pairs for control characters
-struct HexPair(u8, u8);
-
-static HEX_BYTES: [HexPair; 32] = [
-    HexPair(b'0', b'0'),
-    HexPair(b'0', b'1'),
-    HexPair(b'0', b'2'),
-    HexPair(b'0', b'3'),
-    HexPair(b'0', b'4'),
-    HexPair(b'0', b'5'),
-    HexPair(b'0', b'6'),
-    HexPair(b'0', b'7'),
-    HexPair(b'0', b'8'),
-    HexPair(b'0', b'9'),
-    HexPair(b'0', b'a'),
-    HexPair(b'0', b'b'),
-    HexPair(b'0', b'c'),
-    HexPair(b'0', b'd'),
-    HexPair(b'0', b'e'),
-    HexPair(b'0', b'f'),
-    HexPair(b'1', b'0'),
-    HexPair(b'1', b'1'),
-    HexPair(b'1', b'2'),
-    HexPair(b'1', b'3'),
-    HexPair(b'1', b'4'),
-    HexPair(b'1', b'5'),
-    HexPair(b'1', b'6'),
-    HexPair(b'1', b'7'),
-    HexPair(b'1', b'8'),
-    HexPair(b'1', b'9'),
-    HexPair(b'1', b'a'),
-    HexPair(b'1', b'b'),
-    HexPair(b'1', b'c'),
-    HexPair(b'1', b'd'),
-    HexPair(b'1', b'e'),
-    HexPair(b'1', b'f'),
-];
 
 #[test]
 fn test_escape_json_string() {


### PR DESCRIPTION
benchmark results on GitHub actions runner: https://docs.rs/json-escape-simd/latest/json_escape_simd/

### GitHub Actions x86_64 (`ubuntu-latest`)

`AVX2` enabled.

**RxJS payload (~10k iterations)**

| Implementation        | Median time   | vs fastest |
| --------------------- | ------------- | ---------- |
| **`escape simd`**     | **345.06 µs** | **1.00×**  |
| `escape v_jsonescape` | 576.25 µs     | 1.67×      |
| `escape generic`      | 657.94 µs     | 1.91×      |
| `serde_json`          | 766.72 µs     | 2.22×      |
| `json-escape`         | 782.65 µs     | 2.27×      |

**Escape AFFiNE sources  (~300 iterations)**

| Implementation        | Median time  | vs fastest |
| --------------------- | ------------ | ---------- |
| **`escape simd`**     | **12.84 ms** | **1.00×**  |
| `escape v_jsonescape` | 19.66 ms     | 1.53×      |
| `escape generic`      | 22.53 ms     | 1.75×      |
| `serde_json`          | 24.65 ms     | 1.92×      |
| `json-escape`         | 26.64 ms     | 2.07×      |