### PR TITLE
perf: reduce string allocation in sourcemap encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- use simd optimzed json string escape impl ([#158](https://github.com/oxc-project/oxc-sourcemap/pull/158))
+- use simd optimized json string escape impl ([#158](https://github.com/oxc-project/oxc-sourcemap/pull/158))
 - enable fat lto in bench profile ([#161](https://github.com/oxc-project/oxc-sourcemap/pull/161))
 
 ## [4.1.2](https://github.com/oxc-project/oxc-sourcemap/compare/v4.1.1...v4.1.2) - 2025-09-18

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "json-escape-simd"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc1cc6a0d3d3e002739c6c2bef8944614100173c4a5c1af0c2e5ee36bf3b5a3"
+checksum = "2a1f7d5786a4cb0f4e0f862b562a0e085b5bfa23a4f0dc05e7b823ed4e4d791f"
 dependencies = [
  "anyhow",
 ]


### PR DESCRIPTION
Only allocate once in fn `to_json_string`