### PR TITLE
chore: release v4.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.4](https://github.com/oxc-project/oxc-sourcemap/compare/v4.1.3...v4.1.4) - 2025-09-24
+
+### Other
+
+- reduce string allocation in sourcemap encoding ([#163](https://github.com/oxc-project/oxc-sourcemap/pull/163))
+
 ## [4.1.3](https://github.com/oxc-project/oxc-sourcemap/compare/v4.1.2...v4.1.3) - 2025-09-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "oxc_sourcemap"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "base64-simd",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_sourcemap"
-version = "4.1.3"
+version = "4.1.4"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `oxc_sourcemap`: 4.1.3 -> 4.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [4.1.4](https://github.com/oxc-project/oxc-sourcemap/compare/v4.1.3...v4.1.4) - 2025-09-24

### Other

- reduce string allocation in sourcemap encoding ([#163](https://github.com/oxc-project/oxc-sourcemap/pull/163))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).