### PR TITLE
fix: take `;` into account when estimating mappings length

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,5 @@
+[default]
+extend-ignore-re = [
+  "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
+  "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
+]


### PR DESCRIPTION
This debug assertion failed for the case I added in the tests.
https://github.com/oxc-project/oxc-sourcemap/blob/2ff467174c9c513ed4d212bd6bbeec430018586c/src/encode.rs#L156-L157

This is because `;` was not taken into account when estimating the mappings length.
