### PR TITLE
chore: tweak `x_google_ignore_list` comment and add assertion

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -90,8 +90,12 @@ pub fn encode_to_string(sourcemap: &SourceMap) -> String {
     if let Some(x_google_ignore_list) = &sourcemap.x_google_ignore_list {
         max_segments += 25; // ],"x_google_ignoreList":[
 
+        debug_assert!(
+            x_google_ignore_list.iter().all(|&v| v < 10000),
+            "x_google_ignore_list values must be < 10000"
+        );
         let ig_count = x_google_ignore_list.len();
-        // guess 4 bytes per item
+        // guess 4 digits per item
         max_segments += 4 * ig_count;
     }
 


### PR DESCRIPTION
A minor clarification to make it a bit more easier to understand the code that came up while working on #167.

"bytes" felt like it's 4 byte number rather than 4 digit characters to me.