### PR TITLE
chore: release v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.0](https://github.com/oxc-project/oxc-sourcemap/compare/v4.1.6...v4.2.0) - 2025-09-26
+
+### Added
+
+- reduce peak memory usage with `.shrink_to_fit()` ([#172](https://github.com/oxc-project/oxc-sourcemap/pull/172))
+
 ## [4.1.6](https://github.com/oxc-project/oxc-sourcemap/compare/v4.1.5...v4.1.6) - 2025-09-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "oxc_sourcemap"
-version = "4.1.6"
+version = "4.2.0"
 dependencies = [
  "base64-simd",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_sourcemap"
-version = "4.1.6"
+version = "4.2.0"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `oxc_sourcemap`: 4.1.6 -> 4.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [4.2.0](https://github.com/oxc-project/oxc-sourcemap/compare/v4.1.6...v4.2.0) - 2025-09-26

### Added

- reduce peak memory usage with `.shrink_to_fit()` ([#172](https://github.com/oxc-project/oxc-sourcemap/pull/172))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).