### PR TITLE
chore: release v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.1](https://github.com/oxc-project/oxc-sourcemap/compare/v4.2.0...v4.2.1) - 2025-09-27
+
+### Other
+
+- reduce memory usage by replacing Vec<Token> with Box<[Token]>
+- replace !0 with INVALID_ID constant for better readability ([#175](https://github.com/oxc-project/oxc-sourcemap/pull/175))
+- remove outdated comment for `TokenChunk`
+
 ## [4.2.0](https://github.com/oxc-project/oxc-sourcemap/compare/v4.1.6...v4.2.0) - 2025-09-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "oxc_sourcemap"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "base64-simd",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_sourcemap"
-version = "4.2.0"
+version = "4.2.1"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2024"

--- a/src/concat_sourcemap_builder.rs
+++ b/src/concat_sourcemap_builder.rs
@@ -213,7 +213,8 @@ where
             Token::new(1, 1, 1, 1, Some(0), Some(0)),
             Token::new(3, 1, 1, 1, Some(1), Some(2)),
             Token::new(3, 2, 2, 2, Some(2), Some(3)),
-        ].into_boxed_slice(),
+        ]
+        .into_boxed_slice(),
         None,
     );
     let concat_sm = builder.into_sourcemap();

--- a/src/concat_sourcemap_builder.rs
+++ b/src/concat_sourcemap_builder.rs
@@ -146,7 +146,7 @@ impl ConcatSourceMapBuilder {
             None,
             self.sources,
             self.source_contents,
-            self.tokens,
+            self.tokens.into_boxed_slice(),
             Some(self.token_chunks),
         )
     }
@@ -179,7 +179,7 @@ where
         None,
         vec!["foo.js".into()],
         vec![],
-        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))],
+        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
         None,
     );
     let sm2 = SourceMap::new(
@@ -188,7 +188,7 @@ where
         None,
         vec!["bar.js".into()],
         vec![],
-        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))],
+        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
         None,
     );
     let sm3 = SourceMap::new(
@@ -197,7 +197,7 @@ where
         None,
         vec!["abc.js".into()],
         vec![],
-        vec![Token::new(1, 2, 2, 2, Some(0), Some(0))],
+        vec![Token::new(1, 2, 2, 2, Some(0), Some(0))].into_boxed_slice(),
         None,
     );
 
@@ -213,7 +213,7 @@ where
             Token::new(1, 1, 1, 1, Some(0), Some(0)),
             Token::new(3, 1, 1, 1, Some(1), Some(2)),
             Token::new(3, 2, 2, 2, Some(2), Some(3)),
-        ],
+        ].into_boxed_slice(),
         None,
     );
     let concat_sm = builder.into_sourcemap();

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -44,7 +44,7 @@ pub fn decode(json: JSONSourceMap) -> Result<SourceMap> {
             .sources_content
             .map(|content| content.into_iter().map(|c| c.map(Arc::from)).collect())
             .unwrap_or_default(),
-        tokens,
+        tokens: tokens.into_boxed_slice(),
         token_chunks: None,
         x_google_ignore_list: json.x_google_ignore_list,
         debug_id: json.debug_id,

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -458,7 +458,7 @@ fn test_encode_escape_string() {
         None,
         vec!["\0".into()],
         vec![Some("emoji-👀-\0".into())],
-        vec![],
+        vec![].into_boxed_slice(),
         None,
     );
     sm.set_x_google_ignore_list(vec![0]);

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -15,7 +15,7 @@ pub struct SourceMap {
     pub(crate) source_root: Option<String>,
     pub(crate) sources: Vec<Arc<str>>,
     pub(crate) source_contents: Vec<Option<Arc<str>>>,
-    pub(crate) tokens: Vec<Token>,
+    pub(crate) tokens: Box<[Token]>,
     pub(crate) token_chunks: Option<Vec<TokenChunk>>,
     /// Identifies third-party sources (such as framework code or bundler-generated code), allowing developers to avoid code that they don't want to see or step through, without having to configure this beforehand.
     /// The `x_google_ignoreList` field refers to the `sources` array, and lists the indices of all the known third-party sources in that source map.
@@ -31,7 +31,7 @@ impl SourceMap {
         source_root: Option<String>,
         sources: Vec<Arc<str>>,
         source_contents: Vec<Option<Arc<str>>>,
-        tokens: Vec<Token>,
+        tokens: Box<[Token]>,
         token_chunks: Option<Vec<TokenChunk>>,
     ) -> Self {
         Self {
@@ -286,7 +286,7 @@ fn test_sourcemap_source_view_token() {
         None,
         vec!["foo.js".into()],
         vec![],
-        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))],
+        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
         None,
     );
     let mut source_view_tokens = sm.get_source_view_tokens();

--- a/src/sourcemap_builder.rs
+++ b/src/sourcemap_builder.rs
@@ -95,7 +95,7 @@ impl SourceMapBuilder {
             None,
             self.sources,
             self.source_contents,
-            self.tokens,
+            self.tokens.into_boxed_slice(),
             self.token_chunks,
         )
     }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -28,7 +28,8 @@ fn invalid_token_position() {
             Token::new(0, 0, 0, 0, Some(0), None),
             Token::new(0, 10, 0, 0, Some(0), None),
             Token::new(0, 0, 0, 10, Some(0), None),
-        ].into_boxed_slice(),
+        ]
+        .into_boxed_slice(),
         None,
     );
     let js = "abc\ndef\n";

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -28,7 +28,7 @@ fn invalid_token_position() {
             Token::new(0, 0, 0, 0, Some(0), None),
             Token::new(0, 10, 0, 0, Some(0), None),
             Token::new(0, 0, 0, 10, Some(0), None),
-        ],
+        ].into_boxed_slice(),
         None,
     );
     let js = "abc\ndef\n";


### PR DESCRIPTION



## 🤖 New release

* `oxc_sourcemap`: 4.2.0 -> 4.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [4.2.1](https://github.com/oxc-project/oxc-sourcemap/compare/v4.2.0...v4.2.1) - 2025-09-27

### Other

- reduce memory usage by replacing Vec<Token> with Box<[Token]>
- replace !0 with INVALID_ID constant for better readability ([#175](https://github.com/oxc-project/oxc-sourcemap/pull/175))
- remove outdated comment for `TokenChunk`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).