### PR TITLE
chore: release v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.1](https://github.com/oxc-project/oxc-sourcemap/compare/v4.2.0...v4.2.1) - 2025-09-27
+
+### Other
+
+- reduce memory usage by replacing Vec<Token> with Box<[Token]>
+- replace !0 with INVALID_ID constant for better readability ([#175](https://github.com/oxc-project/oxc-sourcemap/pull/175))
+- remove outdated comment for `TokenChunk`
+
 ## [4.2.0](https://github.com/oxc-project/oxc-sourcemap/compare/v4.1.6...v4.2.0) - 2025-09-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "oxc_sourcemap"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "base64-simd",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_sourcemap"
-version = "4.2.0"
+version = "4.2.1"
 authors = ["Boshen <boshenc@gmail.com>"]
 categories = []
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `oxc_sourcemap`: 4.2.0 -> 4.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [4.2.1](https://github.com/oxc-project/oxc-sourcemap/compare/v4.2.0...v4.2.1) - 2025-09-27

### Other

- reduce memory usage by replacing Vec<Token> with Box<[Token]>
- replace !0 with INVALID_ID constant for better readability ([#175](https://github.com/oxc-project/oxc-sourcemap/pull/175))
- remove outdated comment for `TokenChunk`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).