### PR TITLE
bench: add synthesized real_xlarge fixture

### DIFF
--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -7,7 +7,7 @@ use std::{
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use oxc_sourcemap::{ConcatSourceMapBuilder, SourceMap, SourceMapBuilder};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Fixture {
     name: String,
     json: String,
@@ -33,7 +33,7 @@ fn load_perf_fixtures() -> Vec<Fixture> {
     fixture_paths.sort_unstable();
     assert!(!fixture_paths.is_empty(), "no perf fixtures found at {}", perf_dir.display());
 
-    fixture_paths
+    let mut fixtures: Vec<Fixture> = fixture_paths
         .into_iter()
         .map(|path| {
             let json = fs::read_to_string(&path).unwrap_or_else(|err| {
@@ -43,7 +43,71 @@ fn load_perf_fixtures() -> Vec<Fixture> {
                 path.file_stem().and_then(|stem| stem.to_str()).unwrap_or("unnamed").to_string();
             Fixture { name, json }
         })
-        .collect()
+        .collect();
+
+    // The on-disk fixtures top out at ~3 KB which leaves benchmarks dominated
+    // by per-iteration overhead. Append a synthesized "real_xlarge" by
+    // concatenating the largest fixture's source/mapping data so we exercise
+    // the parser on a workload closer to real bundler output.
+    if let Some(large) = fixtures.iter().find(|f| f.name == "real_large").cloned() {
+        const REPEATS: usize = 40;
+        let xlarge_json = synthesize_xlarge(&large.json, REPEATS);
+        fixtures.push(Fixture { name: "real_xlarge".to_string(), json: xlarge_json });
+    }
+
+    fixtures
+}
+
+fn synthesize_xlarge(base_json: &str, repeats: usize) -> String {
+    let base: serde_json::Value =
+        serde_json::from_str(base_json).expect("base fixture must be valid JSON");
+    let base = base.as_object().expect("base fixture must be an object");
+
+    let base_sources = base["sources"].as_array().unwrap();
+    let base_sources_content = base["sourcesContent"].as_array().unwrap();
+    let base_names = base["names"].as_array().unwrap();
+    let base_mappings = base["mappings"].as_str().unwrap();
+
+    // Mappings are delta-encoded; repeating them naively makes the cumulative
+    // name_id / source_id grow with each chunk. Inflate names / sources /
+    // sources_content arrays accordingly so the bigger deltas remain valid.
+    let mut sources = Vec::with_capacity(base_sources.len() * repeats);
+    let mut sources_content = Vec::with_capacity(base_sources_content.len() * repeats);
+    let mut names = Vec::with_capacity(base_names.len() * repeats);
+    for chunk in 0..repeats {
+        for (i, src) in base_sources.iter().enumerate() {
+            sources.push(serde_json::Value::String(format!(
+                "chunk_{chunk}/{}",
+                src.as_str().unwrap_or("source.js")
+            )));
+            sources_content.push(
+                base_sources_content.get(i).cloned().unwrap_or(serde_json::Value::Null),
+            );
+        }
+        for (i, n) in base_names.iter().enumerate() {
+            names.push(serde_json::Value::String(format!(
+                "c{chunk}_{}",
+                n.as_str().unwrap_or(&format!("name_{i}"))
+            )));
+        }
+    }
+
+    let mut mappings = String::with_capacity(base_mappings.len() * repeats + repeats);
+    for chunk in 0..repeats {
+        if chunk > 0 {
+            mappings.push(';');
+        }
+        mappings.push_str(base_mappings);
+    }
+
+    let obj = serde_json::json!({
+        "version": 3,
+        "sources": sources,
+        "sourcesContent": sources_content,
+        "names": names,
+        "mappings": mappings,
+    });
+    serde_json::to_string(&obj).unwrap()
 }
 
 fn token_line_span(sm: &SourceMap) -> u32 {

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -80,9 +80,8 @@ fn synthesize_xlarge(base_json: &str, repeats: usize) -> String {
                 "chunk_{chunk}/{}",
                 src.as_str().unwrap_or("source.js")
             )));
-            sources_content.push(
-                base_sources_content.get(i).cloned().unwrap_or(serde_json::Value::Null),
-            );
+            sources_content
+                .push(base_sources_content.get(i).cloned().unwrap_or(serde_json::Value::Null));
         }
         for (i, n) in base_names.iter().enumerate() {
             names.push(serde_json::Value::String(format!(


### PR DESCRIPTION
## Summary

The on-disk perf fixtures top out at ~3 KB, which leaves the bench results dominated by per-iteration overhead. Add a synthesized \`real_xlarge\` fixture (~120 KB, 40× the largest on-disk fixture) so the parser/serializer get exercised on a workload closer to real bundler output and the variance is low enough to discriminate ~5% changes.

## Approach

- Repeat the existing \`real_large\` mapping 40 times with \`;\` separators (line breaks).
- Mappings are delta-encoded, so cumulative \`source_id\` / \`name_id\` grow with each repeat — \`sources\`, \`sourcesContent\`, and \`names\` arrays are inflated accordingly so the deltas remain in range.
- No code or behavior change; the new fixture only appears in benchmark runs.

## Sample numbers

\`\`\`
parse/real_xlarge       time:   [118.97 µs 119.35 µs 119.83 µs]
                        thrpt:  [958.31 MiB/s 962.19 MiB/s 965.29 MiB/s]
serialize/real_xlarge   time:   [44.503 µs 44.645 µs 44.797 µs]
                        thrpt:  [2.5034 GiB/s 2.5120 GiB/s 2.5200 GiB/s]
lookup_table/real_xlarge time:  [3.4425 µs 3.4688 µs 3.4998 µs]
                        thrpt:  [32.044 GiB/s 32.330 GiB/s 32.577 GiB/s]
\`\`\`