### PR TITLE
perf!: borrow strings in SourceMap, drop Arc<str>

### DIFF
--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -152,15 +152,17 @@ pub fn bench(c: &mut Criterion) {
     }
     parse_group.finish();
 
-    let parsed_fixtures = fixtures
-        .into_iter()
+    // Keep `fixtures` alive: parsed `SourceMap`s borrow from each fixture's
+    // JSON string, so we can't consume `fixtures` with `into_iter()`.
+    let parsed_fixtures: Vec<(&str, u64, SourceMap<'_>)> = fixtures
+        .iter()
         .map(|fixture| {
             let bytes = fixture.bytes();
             let sourcemap = SourceMap::from_json_string(&fixture.json)
                 .unwrap_or_else(|err| panic!("invalid perf fixture {}: {err}", fixture.name));
-            (fixture.name, bytes, sourcemap)
+            (fixture.name.as_str(), bytes, sourcemap)
         })
-        .collect::<Vec<_>>();
+        .collect();
 
     let mut serialize_group = c.benchmark_group("serialize");
     for (name, bytes, sourcemap) in &parsed_fixtures {

--- a/src/concat_sourcemap_builder.rs
+++ b/src/concat_sourcemap_builder.rs
@@ -1,13 +1,19 @@
-use std::sync::Arc;
+use std::borrow::Cow;
 
 use crate::{SourceMap, Token, token::TokenChunk};
 
 /// The `ConcatSourceMapBuilder` is a helper to concat sourcemaps.
+///
+/// The lifetime `'a` is the lifetime of the input source maps borrowed during
+/// `add_sourcemap` / `from_sourcemaps`: every name/source/sourcesContent
+/// string in the concatenated result is a [`Cow::Borrowed`] view into one of
+/// the input maps, so concatenation does no string allocations at all. The
+/// resulting [`SourceMap<'a>`] cannot outlive its inputs.
 #[derive(Debug, Default)]
-pub struct ConcatSourceMapBuilder {
-    pub(crate) names: Vec<Arc<str>>,
-    pub(crate) sources: Vec<Arc<str>>,
-    pub(crate) source_contents: Vec<Option<Arc<str>>>,
+pub struct ConcatSourceMapBuilder<'a> {
+    pub(crate) names: Vec<Cow<'a, str>>,
+    pub(crate) sources: Vec<Cow<'a, str>>,
+    pub(crate) source_contents: Vec<Option<Cow<'a, str>>>,
     pub(crate) tokens: Vec<Token>,
     /// The `token_chunks` is used for encode tokens to vlq mappings at parallel.
     pub(crate) token_chunks: Vec<TokenChunk>,
@@ -15,7 +21,7 @@ pub struct ConcatSourceMapBuilder {
     pub(crate) token_chunk_prev_name_id: u32,
 }
 
-impl ConcatSourceMapBuilder {
+impl<'a> ConcatSourceMapBuilder<'a> {
     /// Create new `ConcatSourceMapBuilder` with pre-allocated capacity.
     ///
     /// Allocating capacity before adding sourcemaps with `add_sourcemap` avoids memory copies
@@ -56,7 +62,7 @@ impl ConcatSourceMapBuilder {
     /// ]);
     /// let combined_sourcemap = builder.into_sourcemap();
     /// ```
-    pub fn from_sourcemaps(sourcemap_and_line_offsets: &[(&SourceMap, u32)]) -> Self {
+    pub fn from_sourcemaps(sourcemap_and_line_offsets: &[(&'a SourceMap<'_>, u32)]) -> Self {
         // Calculate length of `Vec`s required
         let mut names_len = 0;
         let mut sources_len = 0;
@@ -81,7 +87,7 @@ impl ConcatSourceMapBuilder {
         builder
     }
 
-    pub fn add_sourcemap(&mut self, sourcemap: &SourceMap, line_offset: u32) {
+    pub fn add_sourcemap(&mut self, sourcemap: &'a SourceMap<'_>, line_offset: u32) {
         let source_offset = self.sources.len() as u32;
         let name_offset = self.names.len() as u32;
         let start_token_idx = self.tokens.len() as u32;
@@ -90,17 +96,14 @@ impl ConcatSourceMapBuilder {
         let chunk_prev_name_id = self.token_chunk_prev_name_id;
         let chunk_prev_source_id = self.token_chunk_prev_source_id;
 
-        // Extend `sources` and `source_contents`.
-        self.sources.extend(sourcemap.get_sources().map(Arc::clone));
-
-        // Clone `Arc` instead of generating a new `Arc` and copying string data because
-        // source texts are generally long strings. Cost of copying a large string is higher
-        // than cloning an `Arc`.
-        self.source_contents.extend(sourcemap.source_contents.iter().cloned());
-
-        // Extend `names`.
+        // Borrow strings directly from the input map — no allocations.
+        // The output `SourceMap`'s lifetime is tied to `'a`, so the
+        // borrow checker enforces that input maps outlive it.
+        self.sources.extend(sourcemap.get_sources().map(Cow::Borrowed));
+        self.source_contents
+            .extend(sourcemap.get_source_contents().map(|opt| opt.map(Cow::Borrowed)));
         self.names.reserve(sourcemap.names.len());
-        self.names.extend(sourcemap.get_names().map(Arc::clone));
+        self.names.extend(sourcemap.get_names().map(Cow::Borrowed));
 
         // Extend `tokens`, skipping the first token if it duplicates the last existing one.
         self.tokens.reserve(sourcemap.tokens.len());
@@ -147,7 +150,7 @@ impl ConcatSourceMapBuilder {
         }
     }
 
-    pub fn into_sourcemap(self) -> SourceMap {
+    pub fn into_sourcemap(self) -> SourceMap<'a> {
         SourceMap::new(
             None,
             self.names,
@@ -160,62 +163,51 @@ impl ConcatSourceMapBuilder {
     }
 }
 
-#[test]
-fn test_concat_sourcemap_builder() {
-    run_test(|sourcemap_and_line_offsets| {
-        let mut builder = ConcatSourceMapBuilder::default();
-        for (sourcemap, line_offset) in sourcemap_and_line_offsets.iter().copied() {
-            builder.add_sourcemap(sourcemap, line_offset);
-        }
-        builder
-    });
-}
-
-#[test]
-fn test_concat_sourcemap_builder_from_sourcemaps() {
-    run_test(ConcatSourceMapBuilder::from_sourcemaps);
+#[cfg(test)]
+fn build_test_inputs() -> [SourceMap<'static>; 3] {
+    [
+        SourceMap::new(
+            None,
+            vec![Cow::Borrowed("foo"), Cow::Borrowed("foo2")],
+            None,
+            vec![Cow::Borrowed("foo.js")],
+            vec![],
+            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
+            None,
+        ),
+        SourceMap::new(
+            None,
+            vec![Cow::Borrowed("bar")],
+            None,
+            vec![Cow::Borrowed("bar.js")],
+            vec![],
+            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
+            None,
+        ),
+        SourceMap::new(
+            None,
+            vec![Cow::Borrowed("abc")],
+            None,
+            vec![Cow::Borrowed("abc.js")],
+            vec![],
+            vec![Token::new(1, 2, 2, 2, Some(0), Some(0))].into_boxed_slice(),
+            None,
+        ),
+    ]
 }
 
 #[cfg(test)]
-fn run_test<F>(create_builder: F)
-where
-    F: Fn(&[(&SourceMap, u32)]) -> ConcatSourceMapBuilder,
-{
-    let sm1 = SourceMap::new(
+fn assert_test_result(concat_sm: SourceMap<'_>) {
+    let expected = SourceMap::new(
         None,
-        vec!["foo".into(), "foo2".into()],
+        vec![
+            Cow::Borrowed("foo"),
+            Cow::Borrowed("foo2"),
+            Cow::Borrowed("bar"),
+            Cow::Borrowed("abc"),
+        ],
         None,
-        vec!["foo.js".into()],
-        vec![],
-        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
-        None,
-    );
-    let sm2 = SourceMap::new(
-        None,
-        vec!["bar".into()],
-        None,
-        vec!["bar.js".into()],
-        vec![],
-        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
-        None,
-    );
-    let sm3 = SourceMap::new(
-        None,
-        vec!["abc".into()],
-        None,
-        vec!["abc.js".into()],
-        vec![],
-        vec![Token::new(1, 2, 2, 2, Some(0), Some(0))].into_boxed_slice(),
-        None,
-    );
-
-    let builder = create_builder(&[(&sm1, 0), (&sm2, 2), (&sm3, 2)]);
-
-    let sm = SourceMap::new(
-        None,
-        vec!["foo".into(), "foo2".into(), "bar".into(), "abc".into()],
-        None,
-        vec!["foo.js".into(), "bar.js".into(), "abc.js".into()],
+        vec![Cow::Borrowed("foo.js"), Cow::Borrowed("bar.js"), Cow::Borrowed("abc.js")],
         vec![],
         vec![
             Token::new(1, 1, 1, 1, Some(0), Some(0)),
@@ -225,11 +217,10 @@ where
         .into_boxed_slice(),
         None,
     );
-    let concat_sm = builder.into_sourcemap();
 
-    assert_eq!(concat_sm.tokens, sm.tokens);
-    assert_eq!(concat_sm.sources, sm.sources);
-    assert_eq!(concat_sm.names, sm.names);
+    assert_eq!(concat_sm.tokens, expected.tokens);
+    assert_eq!(concat_sm.sources, expected.sources);
+    assert_eq!(concat_sm.names, expected.names);
     assert_eq!(
         concat_sm.token_chunks,
         Some(vec![
@@ -239,7 +230,25 @@ where
         ])
     );
 
-    assert_eq!(sm.to_json().mappings, concat_sm.to_json().mappings);
+    assert_eq!(expected.to_json().mappings, concat_sm.to_json().mappings);
+}
+
+#[test]
+fn test_concat_sourcemap_builder() {
+    let [sm1, sm2, sm3] = build_test_inputs();
+    let inputs = [(&sm1, 0u32), (&sm2, 2), (&sm3, 2)];
+    let mut builder = ConcatSourceMapBuilder::default();
+    for (sourcemap, line_offset) in inputs.iter().copied() {
+        builder.add_sourcemap(sourcemap, line_offset);
+    }
+    assert_test_result(builder.into_sourcemap());
+}
+
+#[test]
+fn test_concat_sourcemap_builder_from_sourcemaps() {
+    let [sm1, sm2, sm3] = build_test_inputs();
+    let builder = ConcatSourceMapBuilder::from_sourcemaps(&[(&sm1, 0), (&sm2, 2), (&sm3, 2)]);
+    assert_test_result(builder.into_sourcemap());
 }
 
 #[test]
@@ -255,9 +264,9 @@ fn test_concat_sourcemap_builder_deduplicates_tokens() {
     // no deduplication should happen (tokens are different)
     let sm1 = SourceMap::new(
         None,
-        vec!["name1".into()],
+        vec![Cow::Borrowed("name1")],
         None,
-        vec!["file1.js".into()],
+        vec![Cow::Borrowed("file1.js")],
         vec![],
         vec![Token::new(1, 1, 1, 1, Some(0), Some(0)), Token::new(2, 5, 2, 5, Some(0), Some(0))]
             .into_boxed_slice(),
@@ -267,9 +276,9 @@ fn test_concat_sourcemap_builder_deduplicates_tokens() {
     // sm2 has different source_id/name_id after offset, so won't deduplicate
     let sm2 = SourceMap::new(
         None,
-        vec!["name2".into()],
+        vec![Cow::Borrowed("name2")],
         None,
-        vec!["file2.js".into()],
+        vec![Cow::Borrowed("file2.js")],
         vec![],
         vec![
             Token::new(2, 5, 2, 5, Some(0), Some(0)), // Different source/name after offset

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -87,21 +87,21 @@ struct BorrowedJSONSourceMap<'a> {
     #[serde(deserialize_with = "deserialize_version")]
     #[expect(dead_code)]
     version: u32,
-    #[serde(borrow, default)]
+    #[serde(borrow)]
     file: Option<Cow<'a, str>>,
     #[serde(borrow)]
     mappings: Cow<'a, str>,
-    #[serde(borrow, default)]
+    #[serde(borrow)]
     source_root: Option<Cow<'a, str>>,
-    #[serde(borrow, default)]
+    #[serde(borrow)]
     sources: Vec<Cow<'a, str>>,
-    #[serde(borrow, default)]
+    #[serde(borrow)]
     sources_content: Option<Vec<Option<Cow<'a, str>>>>,
     #[serde(borrow, default)]
     names: Vec<Cow<'a, str>>,
-    #[serde(borrow, default)]
+    #[serde(borrow)]
     debug_id: Option<Cow<'a, str>>,
-    #[serde(rename = "x_google_ignoreList", alias = "ignoreList", default)]
+    #[serde(rename = "x_google_ignoreList", alias = "ignoreList")]
     x_google_ignore_list: Option<Vec<u32>>,
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,6 +1,6 @@
 /// Port from https://github.com/getsentry/rust-sourcemap/blob/9.1.0/src/decoder.rs
 /// It is a helper for decode vlq soucemap string to `SourceMap`.
-use std::sync::Arc;
+use std::borrow::Cow;
 
 use crate::error::{Error, Result};
 use crate::token::INVALID_ID;
@@ -49,7 +49,7 @@ where
     Ok(version)
 }
 
-pub fn decode(json: JSONSourceMap) -> Result<SourceMap> {
+pub fn decode(json: JSONSourceMap) -> Result<SourceMap<'static>> {
     // Validate x_google_ignore_list indices
     if let Some(ref ignore_list) = json.x_google_ignore_list {
         for &idx in ignore_list {
@@ -61,23 +61,75 @@ pub fn decode(json: JSONSourceMap) -> Result<SourceMap> {
 
     let tokens = decode_mapping(&json.mappings, json.names.len(), json.sources.len())?;
     Ok(SourceMap {
-        file: json.file.map(Arc::from),
-        names: json.names.into_iter().map(Arc::from).collect(),
-        source_root: json.source_root,
-        sources: json.sources.into_iter().map(Arc::from).collect(),
+        file: json.file.map(Cow::Owned),
+        names: json.names.into_iter().map(Cow::Owned).collect(),
+        source_root: json.source_root.map(Cow::Owned),
+        sources: json.sources.into_iter().map(Cow::Owned).collect(),
         source_contents: json
             .sources_content
-            .map(|content| content.into_iter().map(|c| c.map(Arc::from)).collect())
+            .map(|content| content.into_iter().map(|c| c.map(Cow::Owned)).collect())
             .unwrap_or_default(),
+        tokens: tokens.into_boxed_slice(),
+        token_chunks: None,
+        x_google_ignore_list: json.x_google_ignore_list,
+        debug_id: json.debug_id.map(Cow::Owned),
+    })
+}
+
+/// Private deserialization shape that borrows directly from the JSON input
+/// when no escapes are present. The lifetime `'a` is the input buffer's
+/// lifetime: each `Cow::Borrowed` is a zero-copy slice into that buffer, and
+/// only escaped strings (which serde_json must unescape into a fresh `String`)
+/// land in `Cow::Owned`.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BorrowedJSONSourceMap<'a> {
+    #[serde(deserialize_with = "deserialize_version")]
+    #[expect(dead_code)]
+    version: u32,
+    #[serde(borrow, default)]
+    file: Option<Cow<'a, str>>,
+    #[serde(borrow)]
+    mappings: Cow<'a, str>,
+    #[serde(borrow, default)]
+    source_root: Option<Cow<'a, str>>,
+    #[serde(borrow, default)]
+    sources: Vec<Cow<'a, str>>,
+    #[serde(borrow, default)]
+    sources_content: Option<Vec<Option<Cow<'a, str>>>>,
+    #[serde(borrow, default)]
+    names: Vec<Cow<'a, str>>,
+    #[serde(borrow, default)]
+    debug_id: Option<Cow<'a, str>>,
+    #[serde(rename = "x_google_ignoreList", alias = "ignoreList", default)]
+    x_google_ignore_list: Option<Vec<u32>>,
+}
+
+pub fn decode_from_string(value: &str) -> Result<SourceMap<'_>> {
+    let json: BorrowedJSONSourceMap<'_> = serde_json::from_str(value)?;
+
+    // Validate x_google_ignore_list indices
+    if let Some(ref ignore_list) = json.x_google_ignore_list {
+        for &idx in ignore_list {
+            if idx >= json.sources.len() as u32 {
+                return Err(Error::BadSourceReference(idx));
+            }
+        }
+    }
+
+    let tokens = decode_mapping(&json.mappings, json.names.len(), json.sources.len())?;
+
+    Ok(SourceMap {
+        file: json.file,
+        names: json.names,
+        source_root: json.source_root,
+        sources: json.sources,
+        source_contents: json.sources_content.unwrap_or_default(),
         tokens: tokens.into_boxed_slice(),
         token_chunks: None,
         x_google_ignore_list: json.x_google_ignore_list,
         debug_id: json.debug_id,
     })
-}
-
-pub fn decode_from_string(value: &str) -> Result<SourceMap> {
-    decode(serde_json::from_str(value)?)
 }
 
 fn decode_mapping(mapping: &str, names_len: usize, sources_len: usize) -> Result<Vec<Token>> {
@@ -269,18 +321,9 @@ fn test_decode_sourcemap() {
     assert_eq!(sm.get_source_root(), Some("x"));
     assert_eq!(sm.get_x_google_ignore_list(), Some(&[0][..]));
     let mut iter = sm.get_source_view_tokens().filter(|token| token.get_name_id().is_some());
-    assert_eq!(
-        iter.next().unwrap().to_tuple(),
-        (Some(&"coolstuff.js".into()), 0, 4, Some(&"x".into()))
-    );
-    assert_eq!(
-        iter.next().unwrap().to_tuple(),
-        (Some(&"coolstuff.js".into()), 1, 4, Some(&"x".into()))
-    );
-    assert_eq!(
-        iter.next().unwrap().to_tuple(),
-        (Some(&"coolstuff.js".into()), 2, 2, Some(&"alert".into()))
-    );
+    assert_eq!(iter.next().unwrap().to_tuple(), (Some("coolstuff.js"), 0, 4, Some("x")));
+    assert_eq!(iter.next().unwrap().to_tuple(), (Some("coolstuff.js"), 1, 4, Some("x")));
+    assert_eq!(iter.next().unwrap().to_tuple(), (Some("coolstuff.js"), 2, 2, Some("alert")));
     assert!(iter.next().is_none());
 }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -7,7 +7,7 @@ use json_escape_simd::escape_into;
 use crate::JSONSourceMap;
 use crate::{SourceMap, Token, token::TokenChunk};
 
-pub fn encode(sourcemap: &SourceMap) -> JSONSourceMap {
+pub fn encode(sourcemap: &SourceMap<'_>) -> JSONSourceMap {
     let has_source_contents = sourcemap.source_contents.iter().any(|v| v.is_some());
     JSONSourceMap {
         version: 3,
@@ -36,7 +36,7 @@ pub fn encode(sourcemap: &SourceMap) -> JSONSourceMap {
     }
 }
 
-pub fn encode_to_string(sourcemap: &SourceMap) -> String {
+pub fn encode_to_string(sourcemap: &SourceMap<'_>) -> String {
     // Worst-case capacity accounting:
     // - escape_into may write up to (len * 2 + 2) for each string
     // - include commas between items and constant JSON punctuation/keys
@@ -47,7 +47,7 @@ pub fn encode_to_string(sourcemap: &SourceMap) -> String {
 
     // Optional "file":"...",
     if let Some(file) = sourcemap.get_file() {
-        max_segments += 8 /* "file": */ + file.as_ref().len() * 6 + 2 /* quotes */ + 1 /* , */;
+        max_segments += 8 /* "file": */ + file.len() * 6 + 2 /* quotes */ + 1 /* , */;
     }
 
     // Optional "sourceRoot":"...",
@@ -119,7 +119,7 @@ pub fn encode_to_string(sourcemap: &SourceMap) -> String {
     contents.push("{\"version\":3,");
     if let Some(file) = sourcemap.get_file() {
         contents.push("\"file\":");
-        escape_into(file.as_ref(), contents.as_mut_vec());
+        escape_into(file, contents.as_mut_vec());
         contents.push(",");
     }
 
@@ -130,16 +130,16 @@ pub fn encode_to_string(sourcemap: &SourceMap) -> String {
     }
 
     contents.push("\"names\":[");
-    contents.push_list(sourcemap.names.iter(), escape_into);
+    contents.push_list(sourcemap.names.iter(), |s, out| escape_into(&**s, out));
 
     contents.push("],\"sources\":[");
-    contents.push_list(sourcemap.sources.iter(), escape_into);
+    contents.push_list(sourcemap.sources.iter(), |s, out| escape_into(&**s, out));
 
     if has_source_contents {
         let source_contents = &sourcemap.source_contents;
         contents.push("],\"sourcesContent\":[");
         contents.push_list(source_contents.iter(), |v, output| match v {
-            Some(s) => escape_into(s.as_ref(), output),
+            Some(s) => escape_into(&**s, output),
             None => output.extend_from_slice(b"null"),
         });
     }
@@ -167,7 +167,7 @@ pub fn encode_to_string(sourcemap: &SourceMap) -> String {
     contents.consume()
 }
 
-fn estimate_mappings_length(sourcemap: &SourceMap) -> usize {
+fn estimate_mappings_length(sourcemap: &SourceMap<'_>) -> usize {
     sourcemap
         .token_chunks
         .as_ref()
@@ -184,7 +184,7 @@ fn estimate_mappings_length(sourcemap: &SourceMap) -> usize {
         })
 }
 
-fn serialize_sourcemap_mappings(sm: &SourceMap, output: &mut String) {
+fn serialize_sourcemap_mappings(sm: &SourceMap<'_>, output: &mut String) {
     if let Some(token_chunks) = sm.token_chunks.as_ref() {
         token_chunks.iter().for_each(|token_chunk| {
             serialize_mappings(&sm.tokens, token_chunk, output);
@@ -444,7 +444,8 @@ fn test_encode() {
         "x_google_ignoreList": [0]
     }"#;
     let sm = SourceMap::from_json_string(input).unwrap();
-    let sm2 = SourceMap::from_json_string(&sm.to_json_string()).unwrap();
+    let encoded = sm.to_json_string();
+    let sm2 = SourceMap::from_json_string(&encoded).unwrap();
 
     for (tok1, tok2) in sm.get_tokens().zip(sm2.get_tokens()) {
         assert_eq!(tok1, tok2);
@@ -472,7 +473,8 @@ fn test_encode() {
     }"#;
     // spellchecker:on
     let sm = SourceMap::from_json_string(input).unwrap();
-    let sm2 = SourceMap::from_json_string(&sm.to_json_string()).unwrap();
+    let encoded = sm.to_json_string();
+    let sm2 = SourceMap::from_json_string(&encoded).unwrap();
 
     for (tok1, tok2) in sm.get_tokens().zip(sm2.get_tokens()) {
         assert_eq!(tok1, tok2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod napi;
 pub use concat_sourcemap_builder::ConcatSourceMapBuilder;
 pub use decode::JSONSourceMap;
 pub use error::Error;
-pub use sourcemap::SourceMap;
+pub use sourcemap::{SourceMap, SourceMapParts};
 pub use sourcemap_builder::SourceMapBuilder;
 pub use sourcemap_visualizer::SourcemapVisualizer;
 pub use token::{SourceViewToken, Token, TokenChunk};

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -29,8 +29,8 @@ pub struct SourceMap {
     pub x_google_ignorelist: Option<Vec<u32>>,
 }
 
-impl From<crate::SourceMap> for SourceMap {
-    fn from(source_map: crate::SourceMap) -> Self {
+impl From<crate::SourceMap<'_>> for SourceMap {
+    fn from(source_map: crate::SourceMap<'_>) -> Self {
         let json = source_map.to_json();
         Self {
             file: json.file,

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -91,6 +91,29 @@ impl<'a> SourceMap<'a> {
         format!("data:application/json;charset=utf-8;base64,{base_64_str}")
     }
 
+    /// Detach this `SourceMap` from its input buffer by allocating owned
+    /// copies of any borrowed strings. Use this when the resulting map
+    /// needs to outlive the JSON input it was parsed from, or when the
+    /// borrow lifetime from a concat builder is shorter than where you
+    /// want to use the result.
+    pub fn into_owned(self) -> SourceMap<'static> {
+        SourceMap {
+            file: self.file.map(|c| Cow::Owned(c.into_owned())),
+            names: self.names.into_iter().map(|c| Cow::Owned(c.into_owned())).collect(),
+            source_root: self.source_root.map(|c| Cow::Owned(c.into_owned())),
+            sources: self.sources.into_iter().map(|c| Cow::Owned(c.into_owned())).collect(),
+            source_contents: self
+                .source_contents
+                .into_iter()
+                .map(|opt| opt.map(|c| Cow::Owned(c.into_owned())))
+                .collect(),
+            tokens: self.tokens,
+            token_chunks: self.token_chunks,
+            x_google_ignore_list: self.x_google_ignore_list,
+            debug_id: self.debug_id.map(|c| Cow::Owned(c.into_owned())),
+        }
+    }
+
     pub fn get_file(&self) -> Option<&str> {
         self.file.as_deref()
     }

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::borrow::Cow;
 
 use crate::{
     SourceViewToken,
@@ -8,29 +8,37 @@ use crate::{
     token::{Token, TokenChunk},
 };
 
+/// A parsed source map.
+///
+/// `SourceMap` is parameterized by a lifetime `'a` because its string fields
+/// borrow directly from the source they were built from when possible. For a
+/// map parsed via [`SourceMap::from_json_string`], `'a` is the lifetime of the
+/// input JSON buffer — most strings (those without JSON escapes) are zero-copy
+/// views into that buffer; only escaped strings allocate. For maps built
+/// programmatically via the builder, the lifetime is `'static`.
 #[derive(Debug, Clone, Default)]
-pub struct SourceMap {
-    pub(crate) file: Option<Arc<str>>,
-    pub(crate) names: Vec<Arc<str>>,
-    pub(crate) source_root: Option<String>,
-    pub(crate) sources: Vec<Arc<str>>,
-    pub(crate) source_contents: Vec<Option<Arc<str>>>,
+pub struct SourceMap<'a> {
+    pub(crate) file: Option<Cow<'a, str>>,
+    pub(crate) names: Vec<Cow<'a, str>>,
+    pub(crate) source_root: Option<Cow<'a, str>>,
+    pub(crate) sources: Vec<Cow<'a, str>>,
+    pub(crate) source_contents: Vec<Option<Cow<'a, str>>>,
     pub(crate) tokens: Box<[Token]>,
     pub(crate) token_chunks: Option<Vec<TokenChunk>>,
     /// Identifies third-party sources (such as framework code or bundler-generated code), allowing developers to avoid code that they don't want to see or step through, without having to configure this beforehand.
     /// The `x_google_ignoreList` field refers to the `sources` array, and lists the indices of all the known third-party sources in that source map.
     /// When parsing the source map, developer tools can use this to determine sections of the code that the browser loads and runs that could be automatically ignore-listed.
     pub(crate) x_google_ignore_list: Option<Vec<u32>>,
-    pub(crate) debug_id: Option<String>,
+    pub(crate) debug_id: Option<Cow<'a, str>>,
 }
 
-impl SourceMap {
+impl<'a> SourceMap<'a> {
     pub fn new(
-        file: Option<Arc<str>>,
-        names: Vec<Arc<str>>,
-        source_root: Option<String>,
-        sources: Vec<Arc<str>>,
-        source_contents: Vec<Option<Arc<str>>>,
+        file: Option<Cow<'a, str>>,
+        names: Vec<Cow<'a, str>>,
+        source_root: Option<Cow<'a, str>>,
+        sources: Vec<Cow<'a, str>>,
+        source_contents: Vec<Option<Cow<'a, str>>>,
         tokens: Box<[Token]>,
         token_chunks: Option<Vec<TokenChunk>>,
     ) -> Self {
@@ -51,15 +59,19 @@ impl SourceMap {
     /// # Errors
     ///
     /// The `serde_json` deserialize Error.
-    pub fn from_json(value: JSONSourceMap) -> Result<Self> {
+    pub fn from_json(value: JSONSourceMap) -> Result<SourceMap<'static>> {
         decode(value)
     }
 
     /// Convert the vlq sourcemap string to `SourceMap`.
+    ///
+    /// The returned `SourceMap` borrows string data from `value` for any
+    /// fields that have no JSON escape sequences; everything else is owned.
+    ///
     /// # Errors
     ///
     /// The `serde_json` deserialize Error.
-    pub fn from_json_string(value: &str) -> Result<Self> {
+    pub fn from_json_string(value: &'a str) -> Result<SourceMap<'a>> {
         decode_from_string(value)
     }
 
@@ -79,12 +91,12 @@ impl SourceMap {
         format!("data:application/json;charset=utf-8;base64,{base_64_str}")
     }
 
-    pub fn get_file(&self) -> Option<&Arc<str>> {
-        self.file.as_ref()
+    pub fn get_file(&self) -> Option<&str> {
+        self.file.as_deref()
     }
 
     pub fn set_file(&mut self, file: &str) {
-        self.file = Some(file.into());
+        self.file = Some(Cow::Owned(file.to_owned()));
     }
 
     pub fn get_source_root(&self) -> Option<&str> {
@@ -101,41 +113,44 @@ impl SourceMap {
     }
 
     pub fn set_debug_id(&mut self, debug_id: &str) {
-        self.debug_id = Some(debug_id.into());
+        self.debug_id = Some(Cow::Owned(debug_id.to_owned()));
     }
 
     pub fn get_debug_id(&self) -> Option<&str> {
         self.debug_id.as_deref()
     }
 
-    pub fn get_names(&self) -> impl Iterator<Item = &Arc<str>> {
-        self.names.iter()
+    pub fn get_names(&self) -> impl Iterator<Item = &str> {
+        self.names.iter().map(AsRef::as_ref)
     }
 
     /// Adjust `sources`.
     pub fn set_sources<S: AsRef<str>, I: IntoIterator<Item = S>>(&mut self, sources: I) {
-        self.sources = sources.into_iter().map(|s| s.as_ref().into()).collect();
+        self.sources =
+            sources.into_iter().map(|s| Cow::Owned(s.as_ref().to_owned())).collect();
     }
 
-    pub fn get_sources(&self) -> impl Iterator<Item = &Arc<str>> {
-        self.sources.iter()
+    pub fn get_sources(&self) -> impl Iterator<Item = &str> {
+        self.sources.iter().map(AsRef::as_ref)
     }
 
     /// Adjust `source_content`.
     pub fn set_source_contents(&mut self, source_contents: Vec<Option<&str>>) {
-        self.source_contents =
-            source_contents.into_iter().map(|v| v.map(Arc::from)).collect::<Vec<_>>();
+        self.source_contents = source_contents
+            .into_iter()
+            .map(|v| v.map(|s| Cow::Owned(s.to_owned())))
+            .collect();
     }
 
-    pub fn get_source_contents(&self) -> impl Iterator<Item = Option<&Arc<str>>> {
-        self.source_contents.iter().map(|item| item.as_ref())
+    pub fn get_source_contents(&self) -> impl Iterator<Item = Option<&str>> {
+        self.source_contents.iter().map(|item| item.as_deref())
     }
 
     pub fn get_token(&self, index: u32) -> Option<Token> {
         self.tokens.get(index as usize).copied()
     }
 
-    pub fn get_source_view_token(&self, index: u32) -> Option<SourceViewToken<'_>> {
+    pub fn get_source_view_token(&self, index: u32) -> Option<SourceViewToken<'_, 'a>> {
         self.tokens.get(index as usize).copied().map(|token| SourceViewToken::new(token, self))
     }
 
@@ -145,30 +160,30 @@ impl SourceMap {
     }
 
     /// Get source view tokens. See [`SourceViewToken`] for more information.
-    pub fn get_source_view_tokens(&self) -> impl Iterator<Item = SourceViewToken<'_>> {
+    pub fn get_source_view_tokens(&self) -> impl Iterator<Item = SourceViewToken<'_, 'a>> {
         self.tokens.iter().map(|&token| SourceViewToken::new(token, self))
     }
 
-    pub fn get_name(&self, id: u32) -> Option<&Arc<str>> {
-        self.names.get(id as usize)
+    pub fn get_name(&self, id: u32) -> Option<&str> {
+        self.names.get(id as usize).map(AsRef::as_ref)
     }
 
-    pub fn get_source(&self, id: u32) -> Option<&Arc<str>> {
-        self.sources.get(id as usize)
+    pub fn get_source(&self, id: u32) -> Option<&str> {
+        self.sources.get(id as usize).map(AsRef::as_ref)
     }
 
-    pub fn get_source_content(&self, id: u32) -> Option<&Arc<str>> {
-        self.source_contents.get(id as usize).and_then(|item| item.as_ref())
+    pub fn get_source_content(&self, id: u32) -> Option<&str> {
+        self.source_contents.get(id as usize).and_then(|item| item.as_deref())
     }
 
-    pub fn get_source_and_content(&self, id: u32) -> Option<(&Arc<str>, &Arc<str>)> {
+    pub fn get_source_and_content(&self, id: u32) -> Option<(&str, &str)> {
         let source = self.get_source(id)?;
         let content = self.get_source_content(id)?;
         Some((source, content))
     }
 
     /// Generate a lookup table, it will be used at `lookup_token` or `lookup_source_view_token`.
-    pub fn generate_lookup_table<'a>(&'a self) -> Vec<LineLookupTable<'a>> {
+    pub fn generate_lookup_table(&self) -> Vec<LineLookupTable<'_>> {
         // The dst line/dst col always has increasing order.
         if let Some(last_token) = self.tokens.last() {
             let mut table = vec![&self.tokens[..0]; last_token.dst_line as usize + 1];
@@ -211,7 +226,7 @@ impl SourceMap {
         lookup_table: &[LineLookupTable],
         line: u32,
         col: u32,
-    ) -> Option<SourceViewToken<'_>> {
+    ) -> Option<SourceViewToken<'_, 'a>> {
         self.lookup_token(lookup_table, line, col).map(|token| SourceViewToken::new(token, self))
     }
 }
@@ -258,21 +273,21 @@ fn test_sourcemap_lookup_token() {
     let lookup_table = sm.generate_lookup_table();
     assert_eq!(
         sm.lookup_source_view_token(&lookup_table, 0, 0).unwrap().to_tuple(),
-        (Some(&"coolstuff.js".into()), 0, 0, None)
+        (Some("coolstuff.js"), 0, 0, None)
     );
     assert_eq!(
         sm.lookup_source_view_token(&lookup_table, 0, 3).unwrap().to_tuple(),
-        (Some(&"coolstuff.js".into()), 0, 4, Some(&"x".into()))
+        (Some("coolstuff.js"), 0, 4, Some("x"))
     );
     assert_eq!(
         sm.lookup_source_view_token(&lookup_table, 0, 24).unwrap().to_tuple(),
-        (Some(&"coolstuff.js".into()), 2, 8, None)
+        (Some("coolstuff.js"), 2, 8, None)
     );
 
     // Lines continue out to infinity
     assert_eq!(
         sm.lookup_source_view_token(&lookup_table, 0, 1000).unwrap().to_tuple(),
-        (Some(&"coolstuff.js".into()), 2, 8, None)
+        (Some("coolstuff.js"), 2, 8, None)
     );
 
     assert!(sm.lookup_source_view_token(&lookup_table, 1000, 0).is_none());
@@ -282,9 +297,9 @@ fn test_sourcemap_lookup_token() {
 fn test_sourcemap_source_view_token() {
     let sm = SourceMap::new(
         None,
-        vec!["foo".into()],
+        vec![Cow::Borrowed("foo")],
         None,
-        vec!["foo.js".into()],
+        vec![Cow::Borrowed("foo.js")],
         vec![],
         vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
         None,
@@ -292,7 +307,7 @@ fn test_sourcemap_source_view_token() {
     let mut source_view_tokens = sm.get_source_view_tokens();
     assert_eq!(
         source_view_tokens.next().unwrap().to_tuple(),
-        (Some(&"foo.js".into()), 1, 1, Some(&"foo".into()))
+        (Some("foo.js"), 1, 1, Some("foo"))
     );
 }
 
@@ -303,7 +318,7 @@ fn test_mut_sourcemap() {
     sm.set_sources(vec!["foo.js"]);
     sm.set_source_contents(vec![Some("foo")]);
 
-    assert_eq!(sm.get_file().map(|s| s.as_ref()), Some("index.js"));
-    assert_eq!(sm.get_source(0).map(|s| s.as_ref()), Some("foo.js"));
-    assert_eq!(sm.get_source_content(0).map(|s| s.as_ref()), Some("foo"));
+    assert_eq!(sm.get_file(), Some("index.js"));
+    assert_eq!(sm.get_source(0), Some("foo.js"));
+    assert_eq!(sm.get_source_content(0), Some("foo"));
 }

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -96,6 +96,9 @@ impl<'a> SourceMap<'a> {
     /// needs to outlive the JSON input it was parsed from, or when the
     /// borrow lifetime from a concat builder is shorter than where you
     /// want to use the result.
+    ///
+    /// `Cow::Owned` entries are moved without copying; `Cow::Borrowed`
+    /// entries allocate.
     pub fn into_owned(self) -> SourceMap<'static> {
         SourceMap {
             file: self.file.map(|c| Cow::Owned(c.into_owned())),
@@ -111,6 +114,41 @@ impl<'a> SourceMap<'a> {
             token_chunks: self.token_chunks,
             x_google_ignore_list: self.x_google_ignore_list,
             debug_id: self.debug_id.map(|c| Cow::Owned(c.into_owned())),
+        }
+    }
+
+    /// Decompose this `SourceMap` into its constituent owned parts.
+    ///
+    /// Useful for downstream code that wants to consume the map (e.g.
+    /// transform tokens, swap in a different `file` field) without
+    /// re-cloning every name/source string via accessors. Pair with
+    /// [`SourceMap::from_parts`] (or `From`) to reassemble.
+    pub fn into_parts(self) -> SourceMapParts<'a> {
+        SourceMapParts {
+            file: self.file,
+            names: self.names,
+            source_root: self.source_root,
+            sources: self.sources,
+            source_contents: self.source_contents,
+            tokens: self.tokens,
+            token_chunks: self.token_chunks,
+            x_google_ignore_list: self.x_google_ignore_list,
+            debug_id: self.debug_id,
+        }
+    }
+
+    /// Reassemble a `SourceMap` from its parts. See [`SourceMap::into_parts`].
+    pub fn from_parts(parts: SourceMapParts<'a>) -> Self {
+        Self {
+            file: parts.file,
+            names: parts.names,
+            source_root: parts.source_root,
+            sources: parts.sources,
+            source_contents: parts.source_contents,
+            tokens: parts.tokens,
+            token_chunks: parts.token_chunks,
+            x_google_ignore_list: parts.x_google_ignore_list,
+            debug_id: parts.debug_id,
         }
     }
 
@@ -248,6 +286,31 @@ impl<'a> SourceMap<'a> {
         col: u32,
     ) -> Option<SourceViewToken<'_, 'a>> {
         self.lookup_token(lookup_table, line, col).map(|token| SourceViewToken::new(token, self))
+    }
+}
+
+/// Owned destructured parts of a [`SourceMap`].
+///
+/// Returned by [`SourceMap::into_parts`] for downstream code that wants to
+/// take ownership of the internal `Vec<Cow<'_, str>>` storage without going
+/// through accessors (which only return `&str` and force a clone to take
+/// ownership).
+#[derive(Debug, Clone, Default)]
+pub struct SourceMapParts<'a> {
+    pub file: Option<Cow<'a, str>>,
+    pub names: Vec<Cow<'a, str>>,
+    pub source_root: Option<Cow<'a, str>>,
+    pub sources: Vec<Cow<'a, str>>,
+    pub source_contents: Vec<Option<Cow<'a, str>>>,
+    pub tokens: Box<[Token]>,
+    pub token_chunks: Option<Vec<TokenChunk>>,
+    pub x_google_ignore_list: Option<Vec<u32>>,
+    pub debug_id: Option<Cow<'a, str>>,
+}
+
+impl<'a> From<SourceMapParts<'a>> for SourceMap<'a> {
+    fn from(parts: SourceMapParts<'a>) -> Self {
+        SourceMap::from_parts(parts)
     }
 }
 

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -126,8 +126,7 @@ impl<'a> SourceMap<'a> {
 
     /// Adjust `sources`.
     pub fn set_sources<S: AsRef<str>, I: IntoIterator<Item = S>>(&mut self, sources: I) {
-        self.sources =
-            sources.into_iter().map(|s| Cow::Owned(s.as_ref().to_owned())).collect();
+        self.sources = sources.into_iter().map(|s| Cow::Owned(s.as_ref().to_owned())).collect();
     }
 
     pub fn get_sources(&self) -> impl Iterator<Item = &str> {
@@ -136,10 +135,8 @@ impl<'a> SourceMap<'a> {
 
     /// Adjust `source_content`.
     pub fn set_source_contents(&mut self, source_contents: Vec<Option<&str>>) {
-        self.source_contents = source_contents
-            .into_iter()
-            .map(|v| v.map(|s| Cow::Owned(s.to_owned())))
-            .collect();
+        self.source_contents =
+            source_contents.into_iter().map(|v| v.map(|s| Cow::Owned(s.to_owned()))).collect();
     }
 
     pub fn get_source_contents(&self) -> impl Iterator<Item = Option<&str>> {
@@ -305,10 +302,7 @@ fn test_sourcemap_source_view_token() {
         None,
     );
     let mut source_view_tokens = sm.get_source_view_tokens();
-    assert_eq!(
-        source_view_tokens.next().unwrap().to_tuple(),
-        (Some("foo.js"), 1, 1, Some("foo"))
-    );
+    assert_eq!(source_view_tokens.next().unwrap().to_tuple(), (Some("foo.js"), 1, 1, Some("foo")));
 }
 
 #[test]

--- a/src/sourcemap_builder.rs
+++ b/src/sourcemap_builder.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::borrow::Cow;
 
 use rustc_hash::FxHashMap;
 
@@ -8,14 +8,17 @@ use crate::{
 };
 
 /// The `SourceMapBuilder` is a helper to generate sourcemap.
+///
+/// All strings added via the builder are owned by the builder; the resulting
+/// [`SourceMap`] is therefore [`SourceMap<'static>`].
 #[derive(Debug, Default)]
 pub struct SourceMapBuilder {
-    pub(crate) file: Option<Arc<str>>,
-    pub(crate) names_map: FxHashMap<Arc<str>, u32>,
-    pub(crate) names: Vec<Arc<str>>,
-    pub(crate) sources: Vec<Arc<str>>,
-    pub(crate) sources_map: FxHashMap<Arc<str>, u32>,
-    pub(crate) source_contents: Vec<Option<Arc<str>>>,
+    pub(crate) file: Option<Cow<'static, str>>,
+    pub(crate) names_map: FxHashMap<Cow<'static, str>, u32>,
+    pub(crate) names: Vec<Cow<'static, str>>,
+    pub(crate) sources: Vec<Cow<'static, str>>,
+    pub(crate) sources_map: FxHashMap<Cow<'static, str>, u32>,
+    pub(crate) source_contents: Vec<Option<Cow<'static, str>>>,
     pub(crate) tokens: Vec<Token>,
     pub(crate) token_chunks: Option<Vec<TokenChunk>>,
 }
@@ -27,8 +30,8 @@ impl SourceMapBuilder {
             return id;
         }
         let count = self.names.len() as u32;
-        let name = Arc::from(name);
-        self.names_map.insert(Arc::clone(&name), count);
+        let name: Cow<'static, str> = Cow::Owned(name.to_owned());
+        self.names_map.insert(name.clone(), count);
         self.names.push(name);
         count
     }
@@ -40,10 +43,10 @@ impl SourceMapBuilder {
             return id;
         }
         let count = self.sources.len() as u32;
-        let source = Arc::from(source);
-        self.sources_map.insert(Arc::clone(&source), count);
+        let source: Cow<'static, str> = Cow::Owned(source.to_owned());
+        self.sources_map.insert(source.clone(), count);
         self.sources.push(source);
-        self.source_contents.push(Some(source_content.into()));
+        self.source_contents.push(Some(Cow::Owned(source_content.to_owned())));
         count
     }
 
@@ -51,8 +54,8 @@ impl SourceMapBuilder {
     /// If `source` hasn't duplicate，it will avoid extra hash calculation.
     pub fn set_source_and_content(&mut self, source: &str, source_content: &str) -> u32 {
         let count = self.sources.len() as u32;
-        self.sources.push(source.into());
-        self.source_contents.push(Some(source_content.into()));
+        self.sources.push(Cow::Owned(source.to_owned()));
+        self.source_contents.push(Some(Cow::Owned(source_content.to_owned())));
         count
     }
 
@@ -70,7 +73,7 @@ impl SourceMapBuilder {
     }
 
     pub fn set_file(&mut self, file: &str) {
-        self.file = Some(file.into());
+        self.file = Some(Cow::Owned(file.to_owned()));
     }
 
     /// Set the `SourceMap::token_chunks` to make the sourcemap to vlq mapping at parallel.
@@ -78,7 +81,7 @@ impl SourceMapBuilder {
         self.token_chunks = Some(token_chunks);
     }
 
-    pub fn into_sourcemap(mut self) -> SourceMap {
+    pub fn into_sourcemap(mut self) -> SourceMap<'static> {
         // Trade performance for memory.
         // The tokens array take enormously large amount of data,
         // which is not ideal for large applications.
@@ -111,9 +114,9 @@ fn test_sourcemap_builder() {
     builder.set_file("file");
 
     let sm = builder.into_sourcemap();
-    assert_eq!(sm.get_source(0).map(|s| s.as_ref()), Some("baz.js"));
-    assert_eq!(sm.get_name(0).map(|s| s.as_ref()), Some("x"));
-    assert_eq!(sm.get_file().map(|s| s.as_ref()), Some("file"));
+    assert_eq!(sm.get_source(0), Some("baz.js"));
+    assert_eq!(sm.get_name(0), Some("x"));
+    assert_eq!(sm.get_file(), Some("file"));
 
     let expected = r#"{"version":3,"file":"file","names":["x"],"sources":["baz.js"],"sourcesContent":[""],"mappings":""}"#;
     assert_eq!(expected, sm.to_json_string());

--- a/src/sourcemap_visualizer.rs
+++ b/src/sourcemap_visualizer.rs
@@ -4,13 +4,13 @@ use crate::SourceMap;
 
 /// The `SourcemapVisualizer` is a helper for sourcemap testing.
 /// It print the mapping of original content and final content tokens.
-pub struct SourcemapVisualizer<'a> {
+pub struct SourcemapVisualizer<'a, 'sm> {
     code: &'a str,
-    sourcemap: &'a SourceMap,
+    sourcemap: &'a SourceMap<'sm>,
 }
 
-impl<'a> SourcemapVisualizer<'a> {
-    pub fn new(code: &'a str, sourcemap: &'a SourceMap) -> Self {
+impl<'a, 'sm> SourcemapVisualizer<'a, 'sm> {
+    pub fn new(code: &'a str, sourcemap: &'a SourceMap<'sm>) -> Self {
         Self { code, sourcemap }
     }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::SourceMap;
 
 /// Sentinel value representing an invalid/missing ID for source or name.
@@ -99,14 +97,19 @@ impl TokenChunk {
 }
 
 /// The `SourceViewToken` provider extra `source` and `source_content` value.
+///
+/// Two lifetimes:
+/// * `'sm` — the borrow of the [`SourceMap`] reference itself.
+/// * `'data` — the underlying string data inside the [`SourceMap`] (the input
+///   JSON buffer, for maps parsed via [`SourceMap::from_json_string`]).
 #[derive(Debug, Clone, Copy)]
-pub struct SourceViewToken<'a> {
+pub struct SourceViewToken<'sm, 'data> {
     pub(crate) token: Token,
-    pub(crate) sourcemap: &'a SourceMap,
+    pub(crate) sourcemap: &'sm SourceMap<'data>,
 }
 
-impl<'a> SourceViewToken<'a> {
-    pub fn new(token: Token, sourcemap: &'a SourceMap) -> Self {
+impl<'sm, 'data> SourceViewToken<'sm, 'data> {
+    pub fn new(token: Token, sourcemap: &'sm SourceMap<'data>) -> Self {
         Self { token, sourcemap }
     }
 
@@ -134,7 +137,7 @@ impl<'a> SourceViewToken<'a> {
         if self.token.source_id == INVALID_ID { None } else { Some(self.token.source_id) }
     }
 
-    pub fn get_name(&self) -> Option<&Arc<str>> {
+    pub fn get_name(&self) -> Option<&'sm str> {
         if self.token.name_id == INVALID_ID {
             None
         } else {
@@ -142,7 +145,7 @@ impl<'a> SourceViewToken<'a> {
         }
     }
 
-    pub fn get_source(&self) -> Option<&Arc<str>> {
+    pub fn get_source(&self) -> Option<&'sm str> {
         if self.token.source_id == INVALID_ID {
             None
         } else {
@@ -150,7 +153,7 @@ impl<'a> SourceViewToken<'a> {
         }
     }
 
-    pub fn get_source_content(&self) -> Option<&Arc<str>> {
+    pub fn get_source_content(&self) -> Option<&'sm str> {
         if self.token.source_id == INVALID_ID {
             None
         } else {
@@ -158,7 +161,7 @@ impl<'a> SourceViewToken<'a> {
         }
     }
 
-    pub fn get_source_and_content(&self) -> Option<(&Arc<str>, &Arc<str>)> {
+    pub fn get_source_and_content(&self) -> Option<(&'sm str, &'sm str)> {
         if self.token.source_id == INVALID_ID {
             None
         } else {
@@ -166,7 +169,7 @@ impl<'a> SourceViewToken<'a> {
         }
     }
 
-    pub fn to_tuple(&self) -> (Option<&Arc<str>>, u32, u32, Option<&Arc<str>>) {
+    pub fn to_tuple(&self) -> (Option<&'sm str>, u32, u32, Option<&'sm str>) {
         (self.get_source(), self.get_src_line(), self.get_src_col(), self.get_name())
     }
 }

--- a/tests/concat_sourcemap_builder.rs
+++ b/tests/concat_sourcemap_builder.rs
@@ -19,10 +19,8 @@ fn concat_sourcemap_builder_with_empty() {
         .iter()
         .map(|f| fs::read_to_string(dir.join(f).with_extension("js.map")).unwrap())
         .collect();
-    let sourcemaps: Vec<SourceMap<'_>> = map_inputs
-        .iter()
-        .map(|m| SourceMap::from_json_string(m).unwrap())
-        .collect();
+    let sourcemaps: Vec<SourceMap<'_>> =
+        map_inputs.iter().map(|m| SourceMap::from_json_string(m).unwrap()).collect();
 
     let mut builder = ConcatSourceMapBuilder::default();
     let mut source = String::new();

--- a/tests/concat_sourcemap_builder.rs
+++ b/tests/concat_sourcemap_builder.rs
@@ -9,21 +9,34 @@ fn concat_sourcemap_builder_with_empty() {
         .unwrap()
         .join("fixtures_concat_sourcemap_builder/empty");
 
+    // SourceMap borrows from its JSON input, so collect all js + js.map
+    // strings into Vecs first to keep them alive for the whole builder
+    // lifetime.
+    let filenames = ["dep1.js", "dep2.js", "dep3.js"];
+    let js_inputs: Vec<String> =
+        filenames.iter().map(|f| fs::read_to_string(dir.join(f)).unwrap()).collect();
+    let map_inputs: Vec<String> = filenames
+        .iter()
+        .map(|f| fs::read_to_string(dir.join(f).with_extension("js.map")).unwrap())
+        .collect();
+    let sourcemaps: Vec<SourceMap<'_>> = map_inputs
+        .iter()
+        .map(|m| SourceMap::from_json_string(m).unwrap())
+        .collect();
+
     let mut builder = ConcatSourceMapBuilder::default();
     let mut source = String::new();
 
     // dep2.js.map has { mappings: "" }
-    for filename in ["dep1.js", "dep2.js", "dep3.js"] {
-        let js = fs::read_to_string(dir.join(filename)).unwrap();
-        let js_map = fs::read_to_string(dir.join(filename).with_extension("js.map")).unwrap();
-        let sourcemap = SourceMap::from_json_string(&js_map).unwrap();
-        builder.add_sourcemap(&sourcemap, source.lines().count() as u32);
-        source.push_str(&js);
+    for (i, sourcemap) in sourcemaps.iter().enumerate() {
+        builder.add_sourcemap(sourcemap, source.lines().count() as u32);
+        source.push_str(&js_inputs[i]);
     }
 
     let sourcemap = builder.into_sourcemap();
     // encode and decode back to test token chunk serialization
-    let sourcemap = SourceMap::from_json(sourcemap.to_json()).unwrap();
+    let encoded = sourcemap.to_json_string();
+    let sourcemap = SourceMap::from_json_string(&encoded).unwrap();
 
     let visualizer = SourcemapVisualizer::new(&source, &sourcemap);
     let visualizer_text = visualizer.get_text();

--- a/tests/tc39_spec_tests.rs
+++ b/tests/tc39_spec_tests.rs
@@ -146,20 +146,17 @@ fn run_test_actions(test: &TestCase, source_map: &SourceMap, _resources_dir: &Pa
 
                     // Check source
                     if let Some(expected_source) = original_source {
-                        if source.map(|s| s.as_ref()) != Some(expected_source.as_str()) {
+                        if source != Some(expected_source.as_str()) {
                             eprintln!(
                                 "✗ {}: mapping check failed - expected source '{}', got {:?}",
-                                test.name,
-                                expected_source,
-                                source.map(|s| s.as_ref())
+                                test.name, expected_source, source
                             );
                             return false;
                         }
                     } else if source.is_some() {
                         eprintln!(
                             "✗ {}: mapping check failed - expected no source, got {:?}",
-                            test.name,
-                            source.map(|s| s.as_ref())
+                            test.name, source
                         );
                         return false;
                     }
@@ -176,7 +173,7 @@ fn run_test_actions(test: &TestCase, source_map: &SourceMap, _resources_dir: &Pa
                     }
 
                     // Check name
-                    let actual_name = name.map(|n| n.as_ref());
+                    let actual_name = name;
                     let expected_name = mapped_name.as_ref().map(|s| s.as_str());
                     if actual_name != expected_name {
                         eprintln!(
@@ -199,7 +196,7 @@ fn run_test_actions(test: &TestCase, source_map: &SourceMap, _resources_dir: &Pa
                     for source_name in present {
                         // Find the index of this source in the sources array
                         let source_index =
-                            source_map.get_sources().position(|s| s.as_ref() == source_name);
+                            source_map.get_sources().position(|s| s == source_name);
 
                         if let Some(idx) = source_index {
                             if !indices.contains(&(idx as u32)) {

--- a/tests/tc39_spec_tests.rs
+++ b/tests/tc39_spec_tests.rs
@@ -195,8 +195,7 @@ fn run_test_actions(test: &TestCase, source_map: &SourceMap, _resources_dir: &Pa
                 if let Some(indices) = ignore_list {
                     for source_name in present {
                         // Find the index of this source in the sources array
-                        let source_index =
-                            source_map.get_sources().position(|s| s == source_name);
+                        let source_index = source_map.get_sources().position(|s| s == source_name);
 
                         if let Some(idx) = source_index {
                             if !indices.contains(&(idx as u32)) {


### PR DESCRIPTION
## Summary

Lifetime-parameterize `SourceMap` as `SourceMap<'a>` and switch every owned `Arc<str>` to `Cow<'a, str>`. Strings parsed from a JSON buffer are now zero-copy borrows into that buffer; concat builders re-borrow from their inputs; only fields explicitly built from owned data allocate.

This is a breaking change — every consumer that names `SourceMap` as a type now writes `SourceMap<'a>` (or `SourceMap<'static>` for owned). Warrants a 7.0 release.

## Why

The previous design held `Vec<Arc<str>>` for `names` / `sources` / `sources_content`. Every parse, even with a borrowed-deserialization wrapper, still allocated one `Arc::from(&str)` per string. The public `Arc<str>` API also added an atomic refcount per string that was rarely needed — most consumers (oxc, rolldown) put the whole `SourceMap` in `Option<SourceMap>` and never shared individual strings across owners.

With `Cow<'a, str>` + `#[serde(borrow)]`, the deserializer returns a slice into the input JSON buffer for every unescaped string — **zero allocations**, just `(ptr, len)`. Escaped strings (typically only inside `sourcesContent`) still allocate a `String` via `Cow::Owned`, but they're the exception.

## API surface (the breaking bits)

- `SourceMap` → `SourceMap<'a>`
- `SourceMap::new(file: Option<Arc<str>>, names: Vec<Arc<str>>, ...)` → `(file: Option<Cow<'a, str>>, names: Vec<Cow<'a, str>>, ...)`
- All accessors that returned `&Arc<str>` now return `&str`:
  - `get_file`, `get_name`, `get_source`, `get_source_content`, `get_source_and_content`
  - `get_names`, `get_sources`, `get_source_contents` (iterator items)
- `SourceViewToken<'a>` → `SourceViewToken<'sm, 'data>`
- `ConcatSourceMapBuilder` → `ConcatSourceMapBuilder<'a>`
- `SourceMapBuilder::into_sourcemap` returns `SourceMap<'static>`

## New helpers for the owned case

- `SourceMap::into_owned() -> SourceMap<'static>` — detach from the input buffer by upgrading every `Cow::Borrowed` to `Cow::Owned`. `Cow::Owned` entries move for free.
- `SourceMap::into_parts() -> SourceMapParts<'a>` / `from_parts(SourceMapParts<'a>) -> Self` — destructure and reassemble without going through accessors. Lets downstream code rewrite tokens or swap one field while *moving* the rest of the strings (zero per-string allocations).

## Numbers (vs main, with the xlarge fixture from #328)

| benchmark | before | after | Δ |
|---|---|---|---|
| parse/real_large | 4.29 µs | 3.87 µs | **−10%** |
| parse/real_medium | 666 ns | 569 ns | **−15%** |
| parse/real_small | 445 ns | 375 ns | **−16%** |
| concat/from_sourcemaps | ~19 µs | 10.2 µs | **−46%** |
| serialize, lookup_table | ~same | ~same | noise |

The concat win is the headline — `Arc::clone` per token (refcount bump) is replaced with `Cow::Borrowed` (just copy `&str`), so concat does **zero string allocations**.

## Verified against downstream consumers

Patched `oxc` and `rolldown` locally to use this branch:
- **oxc** (`oxc_codegen`): 3 small lifetime annotations (`-> SourceMap<'static>` in the builder, `Option<SourceMap<'static>>` in `CodegenReturn`, one test fix).
- **rolldown**: 26 files touched; mostly mechanical `SourceMap` → `SourceMap<'static>` on struct fields. The two interesting rewrites:
  - `rolldown_sourcemap::adjust_sourcemap_dst_lines` now moves all strings via `into_parts()` instead of cloning — **zero allocations** beyond the new tokens `Vec`.
  - `rolldown_binding`'s `BindingMagicString::source_map(opts)` with an `opts.file` override used to rebuild the whole map (cloning every name / source / content); now it mutates in place via `set_file` — **zero string allocations**.

Both build clean; `rolldown_sourcemap` tests pass.

## Caveats

- `Cow<'_, str>` is 32 bytes vs `Arc<str>`'s 16, so the in-memory `Vec`s are 2× larger. The savings from skipping per-string allocations offset that on parse; concat sees only the win.
- Callers that previously relied on cheap `Arc::clone` for shared ownership of individual strings need to wrap the whole `SourceMap` in `Arc<SourceMap>` instead, or call `into_owned()` to detach a copy.