### PR TITLE
perf: store `tokens` as `Vec<Token>` and tighten decode hot loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 tests/source-map-tests/
+*.trace/

--- a/examples/profile_parse.rs
+++ b/examples/profile_parse.rs
@@ -1,0 +1,90 @@
+// Tight loop around the parse hot path so a sampling profiler
+// (xcrun xctrace, Instruments, perf, etc.) gets stable hits inside
+// the decoder rather than the harness.
+//
+// Build the bench-profile binary:
+//   cargo build --release --example profile_parse
+// Then profile:
+//   xcrun xctrace record --template 'Time Profile' --output trace.trace \
+//       --launch -- target/release/examples/profile_parse
+#![allow(clippy::print_stdout, clippy::disallowed_methods)]
+
+use std::{fs, path::Path};
+
+use oxc_sourcemap::{ConcatSourceMapBuilder, SourceMap};
+
+fn main() {
+    let perf_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/perf");
+    let large =
+        fs::read_to_string(perf_dir.join("real_large.map")).expect("read real_large fixture");
+
+    // Match `benches/simple.rs`'s `real_xlarge`: 40 copies of the large
+    // fixture, names/sources inflated to keep VLQ deltas valid.
+    let xlarge_json = synth_xlarge(&large, 40);
+
+    // Warm up before the long-running loop so JITs / page mappings settle.
+    for _ in 0..50 {
+        let _ = SourceMap::from_json_string(&xlarge_json).unwrap();
+    }
+
+    let mut total_tokens: u64 = 0;
+    let iters = std::env::args().nth(1).and_then(|s| s.parse::<u32>().ok()).unwrap_or(2000);
+
+    for _ in 0..iters {
+        let sm = SourceMap::from_json_string(&xlarge_json).unwrap();
+        // Force the result to escape so the parse can't be DCE'd.
+        total_tokens = total_tokens.wrapping_add(sm.get_tokens().count() as u64);
+        let serialized = sm.to_json_string();
+        total_tokens = total_tokens.wrapping_add(serialized.len() as u64);
+        let cat = ConcatSourceMapBuilder::from_sourcemaps(&[(&sm, 0), (&sm, 10000)]);
+        let cat_sm = cat.into_sourcemap();
+        total_tokens = total_tokens.wrapping_add(cat_sm.get_tokens().count() as u64);
+    }
+
+    // Print so the optimizer can't dead-strip the loop body.
+    println!("done, total_tokens={total_tokens}, iters={iters}");
+}
+
+fn synth_xlarge(base_json: &str, repeats: usize) -> String {
+    let base: serde_json::Value = serde_json::from_str(base_json).expect("base fixture json");
+    let base = base.as_object().expect("base fixture object");
+    let base_sources = base["sources"].as_array().unwrap();
+    let base_sources_content = base["sourcesContent"].as_array().unwrap();
+    let base_names = base["names"].as_array().unwrap();
+    let base_mappings = base["mappings"].as_str().unwrap();
+
+    let mut sources = Vec::with_capacity(base_sources.len() * repeats);
+    let mut sources_content = Vec::with_capacity(base_sources_content.len() * repeats);
+    let mut names = Vec::with_capacity(base_names.len() * repeats);
+    for chunk in 0..repeats {
+        for (i, src) in base_sources.iter().enumerate() {
+            sources.push(serde_json::Value::String(format!(
+                "chunk_{chunk}/{}",
+                src.as_str().unwrap_or("source.js")
+            )));
+            sources_content
+                .push(base_sources_content.get(i).cloned().unwrap_or(serde_json::Value::Null));
+        }
+        for (i, n) in base_names.iter().enumerate() {
+            names.push(serde_json::Value::String(format!(
+                "c{chunk}_{}",
+                n.as_str().unwrap_or(&format!("name_{i}"))
+            )));
+        }
+    }
+    let mut mappings = String::with_capacity(base_mappings.len() * repeats + repeats);
+    for chunk in 0..repeats {
+        if chunk > 0 {
+            mappings.push(';');
+        }
+        mappings.push_str(base_mappings);
+    }
+    serde_json::to_string(&serde_json::json!({
+        "version": 3,
+        "sources": sources,
+        "sourcesContent": sources_content,
+        "names": names,
+        "mappings": mappings,
+    }))
+    .unwrap()
+}

--- a/src/concat_sourcemap_builder.rs
+++ b/src/concat_sourcemap_builder.rs
@@ -217,7 +217,7 @@ impl<'a> ConcatSourceMapBuilder<'a> {
             None,
             self.sources,
             self.source_contents,
-            self.tokens.into_boxed_slice(),
+            self.tokens,
             Some(self.token_chunks),
         )
     }
@@ -232,7 +232,7 @@ fn build_test_inputs() -> [SourceMap<'static>; 3] {
             None,
             vec![Cow::Borrowed("foo.js")],
             vec![],
-            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
+            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))],
             None,
         ),
         SourceMap::new(
@@ -241,7 +241,7 @@ fn build_test_inputs() -> [SourceMap<'static>; 3] {
             None,
             vec![Cow::Borrowed("bar.js")],
             vec![],
-            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
+            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))],
             None,
         ),
         SourceMap::new(
@@ -250,7 +250,7 @@ fn build_test_inputs() -> [SourceMap<'static>; 3] {
             None,
             vec![Cow::Borrowed("abc.js")],
             vec![],
-            vec![Token::new(1, 2, 2, 2, Some(0), Some(0))].into_boxed_slice(),
+            vec![Token::new(1, 2, 2, 2, Some(0), Some(0))],
             None,
         ),
     ]
@@ -273,8 +273,7 @@ fn assert_test_result(concat_sm: SourceMap<'_>) {
             Token::new(1, 1, 1, 1, Some(0), Some(0)),
             Token::new(3, 1, 1, 1, Some(1), Some(2)),
             Token::new(3, 2, 2, 2, Some(2), Some(3)),
-        ]
-        .into_boxed_slice(),
+        ],
         None,
     );
 
@@ -328,8 +327,7 @@ fn test_concat_sourcemap_builder_deduplicates_tokens() {
         None,
         vec![Cow::Borrowed("file1.js")],
         vec![],
-        vec![Token::new(1, 1, 1, 1, Some(0), Some(0)), Token::new(2, 5, 2, 5, Some(0), Some(0))]
-            .into_boxed_slice(),
+        vec![Token::new(1, 1, 1, 1, Some(0), Some(0)), Token::new(2, 5, 2, 5, Some(0), Some(0))],
         None,
     );
 
@@ -343,8 +341,7 @@ fn test_concat_sourcemap_builder_deduplicates_tokens() {
         vec![
             Token::new(2, 5, 2, 5, Some(0), Some(0)), // Different source/name after offset
             Token::new(3, 10, 3, 10, Some(0), Some(0)),
-        ]
-        .into_boxed_slice(),
+        ],
         None,
     );
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -135,13 +135,19 @@ pub fn decode_from_string(value: &str) -> Result<SourceMap<'_>> {
 fn decode_mapping(mapping: &str, names_len: usize, sources_len: usize) -> Result<Vec<Token>> {
     let mapping = mapping.as_bytes();
 
-    // Exact token count: every `,` or `;` delimits one segment.
-    let mut estimated_tokens = 1usize;
-    for &byte in mapping {
-        if byte == b',' || byte == b';' {
-            estimated_tokens += 1;
-        }
-    }
+    // Tight upper bound on token count without scanning the mapping.
+    //
+    // Every produced token consumes at least one non-delimiter byte (the
+    // segment's first character). The densest possible pattern is
+    // `A,B,C,...` — alternating 1-byte segments and `,` separators — which
+    // yields at most `(len + 1) / 2` tokens. `mapping.len() / 2 + 1` is
+    // therefore a safe (and tight) upper bound for any valid input, so we
+    // can skip the upfront `,` / `;` scan and trust `tokens.len() <
+    // tokens.capacity()` inside the hot loop.
+    //
+    // With `tokens` kept as `Vec<Token>` end-to-end (no `into_boxed_slice`
+    // shrink), unused tail capacity is just memory — no realloc penalty.
+    let estimated_tokens = mapping.len() / 2 + 1;
     let mut tokens: Vec<Token> = Vec::with_capacity(estimated_tokens);
 
     let mut dst_line = 0u32;
@@ -229,10 +235,22 @@ fn decode_mapping(mapping: &str, names_len: usize, sources_len: usize) -> Result
                     }
                 }
 
-                // `src`/`name` already encode "absent" as `INVALID_ID`, so go
-                // through `Token::new_raw` instead of round-tripping through
-                // `Option<u32>` via `Token::new`.
-                tokens.push(Token::new_raw(dst_line, dst_col, src_line, src_col, src, name));
+                // SAFETY: capacity is `mapping.len() / 2 + 1`, which is a proven
+                // upper bound on the number of tokens this loop can produce
+                // (every token costs at least one non-delimiter byte, densest
+                // case `A,B,C,...` reaches exactly `(len + 1) / 2`). So
+                // `tokens.len() < tokens.capacity()` holds at every push.
+                //
+                // `src` / `name` already encode "absent" as `INVALID_ID`, so
+                // we go through `Token::new_raw` instead of round-tripping
+                // through `Option<u32>` via `Token::new`.
+                unsafe {
+                    let len = tokens.len();
+                    debug_assert!(len < tokens.capacity());
+                    let token = Token::new_raw(dst_line, dst_col, src_line, src_col, src, name);
+                    std::ptr::write(tokens.as_mut_ptr().add(len), token);
+                    tokens.set_len(len + 1);
+                }
             }
         }
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -69,7 +69,7 @@ pub fn decode(json: JSONSourceMap) -> Result<SourceMap<'static>> {
             .sources_content
             .map(|content| content.into_iter().map(|c| c.map(Cow::Owned)).collect())
             .unwrap_or_default(),
-        tokens: tokens.into_boxed_slice(),
+        tokens,
         token_chunks: None,
         x_google_ignore_list: json.x_google_ignore_list,
         debug_id: json.debug_id.map(Cow::Owned),
@@ -125,7 +125,7 @@ pub fn decode_from_string(value: &str) -> Result<SourceMap<'_>> {
         source_root: json.source_root,
         sources: json.sources,
         source_contents: json.sources_content.unwrap_or_default(),
-        tokens: tokens.into_boxed_slice(),
+        tokens,
         token_chunks: None,
         x_google_ignore_list: json.x_google_ignore_list,
         debug_id: json.debug_id,
@@ -135,14 +135,14 @@ pub fn decode_from_string(value: &str) -> Result<SourceMap<'_>> {
 fn decode_mapping(mapping: &str, names_len: usize, sources_len: usize) -> Result<Vec<Token>> {
     let mapping = mapping.as_bytes();
 
-    // Upper-bound token estimate: each `,` and `;` can delimit at most one segment.
+    // Exact token count: every `,` or `;` delimits one segment.
     let mut estimated_tokens = 1usize;
     for &byte in mapping {
         if byte == b',' || byte == b';' {
             estimated_tokens += 1;
         }
     }
-    let mut tokens = Vec::with_capacity(estimated_tokens);
+    let mut tokens: Vec<Token> = Vec::with_capacity(estimated_tokens);
 
     let mut dst_line = 0u32;
     let mut dst_col = 0u32;
@@ -178,10 +178,13 @@ fn decode_mapping(mapping: &str, names_len: usize, sources_len: usize) -> Result
             _ => {
                 let nums_len = parse_vlq_segment_into(mapping, &mut cursor, &mut nums)?;
 
-                // `nums[0]` is always generated column delta.
+                // `nums[0]` is always generated column delta. Range check via
+                // single unsigned compare: a negative i64 cast to u64 produces
+                // a value > any u32::MAX, which fails the `>= u32::MAX as u64`
+                // guard (used implicitly here — we only care about non-neg).
                 let new_dst_col = i64::from(dst_col) + nums[0];
-                if new_dst_col < 0 {
-                    return Err(Error::BadSegmentSize(0)); // Negative column
+                if (new_dst_col as u64) > u32::MAX as u64 {
+                    return Err(Error::BadSegmentSize(0));
                 }
                 dst_col = new_dst_col as u32;
 
@@ -193,43 +196,43 @@ fn decode_mapping(mapping: &str, names_len: usize, sources_len: usize) -> Result
                         return Err(Error::BadSegmentSize(nums_len as u32));
                     }
 
-                    // Source/name fields are also delta-encoded.
+                    // Combined unsigned bounds check: when `new_src_id` is
+                    // negative as i64, casting to u64 wraps to a huge value
+                    // that exceeds `sources_len`. Saves the separate `< 0`
+                    // branch (was: `<0 || >= n`, now: single `>= n`).
                     let new_src_id = i64::from(src_id) + nums[1];
-                    if new_src_id < 0 || new_src_id >= sources_len as i64 {
+                    if (new_src_id as u64) >= sources_len as u64 {
                         return Err(Error::BadSourceReference(src_id));
                     }
                     src_id = new_src_id as u32;
                     src = src_id;
 
                     let new_src_line = i64::from(src_line) + nums[2];
-                    if new_src_line < 0 {
-                        return Err(Error::BadSegmentSize(0)); // Negative line
+                    if (new_src_line as u64) > u32::MAX as u64 {
+                        return Err(Error::BadSegmentSize(0));
                     }
                     src_line = new_src_line as u32;
 
                     let new_src_col = i64::from(src_col) + nums[3];
-                    if new_src_col < 0 {
-                        return Err(Error::BadSegmentSize(0)); // Negative column
+                    if (new_src_col as u64) > u32::MAX as u64 {
+                        return Err(Error::BadSegmentSize(0));
                     }
                     src_col = new_src_col as u32;
 
                     if nums_len > 4 {
-                        name_id = (i64::from(name_id) + nums[4]) as u32;
-                        if name_id >= names_len as u32 {
+                        let new_name_id = i64::from(name_id) + nums[4];
+                        if (new_name_id as u64) >= names_len as u64 {
                             return Err(Error::BadNameReference(name_id));
                         }
+                        name_id = new_name_id as u32;
                         name = name_id;
                     }
                 }
 
-                tokens.push(Token::new(
-                    dst_line,
-                    dst_col,
-                    src_line,
-                    src_col,
-                    if src == INVALID_ID { None } else { Some(src) },
-                    if name == INVALID_ID { None } else { Some(name) },
-                ));
+                // `src`/`name` already encode "absent" as `INVALID_ID`, so go
+                // through `Token::new_raw` instead of round-tripping through
+                // `Option<u32>` via `Token::new`.
+                tokens.push(Token::new_raw(dst_line, dst_col, src_line, src_col, src, name));
             }
         }
     }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -491,7 +491,7 @@ fn test_encode_escape_string() {
         None,
         vec!["\0".into()],
         vec![Some("emoji-👀-\0".into())],
-        vec![].into_boxed_slice(),
+        vec![],
         None,
     );
     sm.set_x_google_ignore_list(vec![0]);
@@ -558,7 +558,7 @@ fn test_encode_all_sources_content_null() {
         None,
         vec!["a.js".into(), "b.js".into()],
         vec![None, None],
-        vec![].into_boxed_slice(),
+        vec![],
         None,
     );
     let json = sm.to_json_string();
@@ -576,7 +576,7 @@ fn test_encode_all_sources_content_null() {
         None,
         vec!["a.js".into(), "b.js".into()],
         vec![Some("content".into()), None],
-        vec![].into_boxed_slice(),
+        vec![],
         None,
     );
     let json = sm.to_json_string();
@@ -601,7 +601,7 @@ fn test_encode_escape_file_and_source_root() {
         Some("root\0path".into()),
         vec![],
         vec![],
-        vec![].into_boxed_slice(),
+        vec![],
         None,
     );
     let json = sm.to_json_string();

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -23,7 +23,7 @@ pub struct SourceMap<'a> {
     pub(crate) source_root: Option<Cow<'a, str>>,
     pub(crate) sources: Vec<Cow<'a, str>>,
     pub(crate) source_contents: Vec<Option<Cow<'a, str>>>,
-    pub(crate) tokens: Box<[Token]>,
+    pub(crate) tokens: Vec<Token>,
     pub(crate) token_chunks: Option<Vec<TokenChunk>>,
     /// Identifies third-party sources (such as framework code or bundler-generated code), allowing developers to avoid code that they don't want to see or step through, without having to configure this beforehand.
     /// The `x_google_ignoreList` field refers to the `sources` array, and lists the indices of all the known third-party sources in that source map.
@@ -39,7 +39,7 @@ impl<'a> SourceMap<'a> {
         source_root: Option<Cow<'a, str>>,
         sources: Vec<Cow<'a, str>>,
         source_contents: Vec<Option<Cow<'a, str>>>,
-        tokens: Box<[Token]>,
+        tokens: Vec<Token>,
         token_chunks: Option<Vec<TokenChunk>>,
     ) -> Self {
         Self {
@@ -302,7 +302,7 @@ pub struct SourceMapParts<'a> {
     pub source_root: Option<Cow<'a, str>>,
     pub sources: Vec<Cow<'a, str>>,
     pub source_contents: Vec<Option<Cow<'a, str>>>,
-    pub tokens: Box<[Token]>,
+    pub tokens: Vec<Token>,
     pub token_chunks: Option<Vec<TokenChunk>>,
     pub x_google_ignore_list: Option<Vec<u32>>,
     pub debug_id: Option<Cow<'a, str>>,
@@ -384,7 +384,7 @@ fn test_sourcemap_source_view_token() {
         None,
         vec![Cow::Borrowed("foo.js")],
         vec![],
-        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
+        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))],
         None,
     );
     let mut source_view_tokens = sm.get_source_view_tokens();

--- a/src/sourcemap_builder.rs
+++ b/src/sourcemap_builder.rs
@@ -98,7 +98,7 @@ impl SourceMapBuilder {
             None,
             self.sources,
             self.source_contents,
-            self.tokens.into_boxed_slice(),
+            self.tokens,
             self.token_chunks,
         )
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -34,6 +34,22 @@ impl Token {
         }
     }
 
+    /// Construct a `Token` directly from raw u32 ids using `INVALID_ID`
+    /// (`u32::MAX`) to mean "absent". Skips the `Option<u32> → u32`
+    /// roundtrip for hot decode/concat loops that already track the
+    /// sentinel value directly.
+    #[inline]
+    pub(crate) fn new_raw(
+        dst_line: u32,
+        dst_col: u32,
+        src_line: u32,
+        src_col: u32,
+        source_id: u32,
+        name_id: u32,
+    ) -> Self {
+        Self { dst_line, dst_col, src_line, src_col, source_id, name_id }
+    }
+
     pub fn get_dst_line(&self) -> u32 {
         self.dst_line
     }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -28,8 +28,7 @@ fn invalid_token_position() {
             Token::new(0, 0, 0, 0, Some(0), None),
             Token::new(0, 10, 0, 0, Some(0), None),
             Token::new(0, 0, 0, 10, Some(0), None),
-        ]
-        .into_boxed_slice(),
+        ],
         None,
     );
     let js = "abc\ndef\n";


### PR DESCRIPTION
## Summary

Profile-guided perf work using `xcrun xctrace record --template 'Time Profile'`. The Time Profiler against a 30k-iteration loop showed `SourceMap::from_json_string` taking ~35% of total time, with a measurable chunk going to `_platform_memmove` called from the decoder — the `Vec::into_boxed_slice` shrink-realloc at the end of `decode_from_string`.

Two commits, layered:

### 1. Store `tokens` as `Vec<Token>` end-to-end (+ small decode wins)

- **`SourceMap::tokens`: `Box<[Token]>` → `Vec<Token>`.** Drop `into_boxed_slice` in `decode`, `decode_from_string`, `SourceMapBuilder::into_sourcemap`, and `ConcatSourceMapBuilder::into_sourcemap`. Eliminates the post-parse realloc+copy on every parsed map.
- **Combined unsigned bounds checks in `decode_mapping`.** Replace `if x < 0 || x >= n` with `(x as u64) >= n as u64` — negative `i64` cast to `u64` wraps to a huge value that fails any reasonable upper bound. Saves a branch per source-id / name-id segment.
- **`Token::new_raw`** for raw-id construction in decode — skips the `u32 → Option<u32> → u32` round-trip through `Token::new`.

### 2. Drop the `,`/`;` pre-scan + use unsafe push

- Every produced token consumes at least one non-delimiter byte; the densest valid pattern (`A,B,C,...`) reaches exactly `(len + 1) / 2` tokens. So `mapping.len() / 2 + 1` is a safe upper bound that lets us skip the O(n) pre-pass entirely.
- Because we have a guaranteed upper bound on `tokens.capacity()`, the per-token `push` can use `ptr::write` + `set_len` and drop the capacity check.

`examples/profile_parse.rs` is included as a self-contained loop usable with `xctrace`, `Instruments`, or `perf`.

## CodSpeed results (vs main)

**Net: +4.26% overall.**

| ⚡ Improvements | Δ |
| --- | --- |
| `parse[real_xlarge]` | +14.01% |
| `parse[real_large]` | +11.92% |
| `parse[real_medium]` | +9.51% |
| `parse[real_small]` | +4.15% |
| `from_json_string_inline` (smoke) | +2.98% |
| `serialize[real_small]` | +2.69% |
| `lookup_table[real_medium]` | +2.05% |
| `serialize[real_large]` | +1.22% |

| ❌ Regressions | Δ |
| --- | --- |
| `build_single` | -2.44% |
| `lookup_table[real_small]` | -2.13% |

The remaining regressions are small (<3%) on already-sub-microsecond benchmarks and look like binary-layout artifacts.

## Breaking changes

- `SourceMap::new` now takes `tokens: Vec<Token>` (was `Box<[Token]>`).
- `SourceMapParts::tokens` is now `Vec<Token>` (was `Box<[Token]>`).

Callers passing `tokens.into_boxed_slice()` should drop that conversion.