### PR TITLE
perf!: store `SourceMap::tokens` as `Vec<Token>`

### DIFF
--- a/src/concat_sourcemap_builder.rs
+++ b/src/concat_sourcemap_builder.rs
@@ -217,7 +217,7 @@ impl<'a> ConcatSourceMapBuilder<'a> {
             None,
             self.sources,
             self.source_contents,
-            self.tokens.into_boxed_slice(),
+            self.tokens,
             Some(self.token_chunks),
         )
     }
@@ -232,7 +232,7 @@ fn build_test_inputs() -> [SourceMap<'static>; 3] {
             None,
             vec![Cow::Borrowed("foo.js")],
             vec![],
-            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
+            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))],
             None,
         ),
         SourceMap::new(
@@ -241,7 +241,7 @@ fn build_test_inputs() -> [SourceMap<'static>; 3] {
             None,
             vec![Cow::Borrowed("bar.js")],
             vec![],
-            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
+            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))],
             None,
         ),
         SourceMap::new(
@@ -250,7 +250,7 @@ fn build_test_inputs() -> [SourceMap<'static>; 3] {
             None,
             vec![Cow::Borrowed("abc.js")],
             vec![],
-            vec![Token::new(1, 2, 2, 2, Some(0), Some(0))].into_boxed_slice(),
+            vec![Token::new(1, 2, 2, 2, Some(0), Some(0))],
             None,
         ),
     ]
@@ -273,8 +273,7 @@ fn assert_test_result(concat_sm: SourceMap<'_>) {
             Token::new(1, 1, 1, 1, Some(0), Some(0)),
             Token::new(3, 1, 1, 1, Some(1), Some(2)),
             Token::new(3, 2, 2, 2, Some(2), Some(3)),
-        ]
-        .into_boxed_slice(),
+        ],
         None,
     );
 
@@ -328,8 +327,7 @@ fn test_concat_sourcemap_builder_deduplicates_tokens() {
         None,
         vec![Cow::Borrowed("file1.js")],
         vec![],
-        vec![Token::new(1, 1, 1, 1, Some(0), Some(0)), Token::new(2, 5, 2, 5, Some(0), Some(0))]
-            .into_boxed_slice(),
+        vec![Token::new(1, 1, 1, 1, Some(0), Some(0)), Token::new(2, 5, 2, 5, Some(0), Some(0))],
         None,
     );
 
@@ -343,8 +341,7 @@ fn test_concat_sourcemap_builder_deduplicates_tokens() {
         vec![
             Token::new(2, 5, 2, 5, Some(0), Some(0)), // Different source/name after offset
             Token::new(3, 10, 3, 10, Some(0), Some(0)),
-        ]
-        .into_boxed_slice(),
+        ],
         None,
     );
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -69,7 +69,7 @@ pub fn decode(json: JSONSourceMap) -> Result<SourceMap<'static>> {
             .sources_content
             .map(|content| content.into_iter().map(|c| c.map(Cow::Owned)).collect())
             .unwrap_or_default(),
-        tokens: tokens.into_boxed_slice(),
+        tokens,
         token_chunks: None,
         x_google_ignore_list: json.x_google_ignore_list,
         debug_id: json.debug_id.map(Cow::Owned),
@@ -125,7 +125,7 @@ pub fn decode_from_string(value: &str) -> Result<SourceMap<'_>> {
         source_root: json.source_root,
         sources: json.sources,
         source_contents: json.sources_content.unwrap_or_default(),
-        tokens: tokens.into_boxed_slice(),
+        tokens,
         token_chunks: None,
         x_google_ignore_list: json.x_google_ignore_list,
         debug_id: json.debug_id,

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -491,7 +491,7 @@ fn test_encode_escape_string() {
         None,
         vec!["\0".into()],
         vec![Some("emoji-👀-\0".into())],
-        vec![].into_boxed_slice(),
+        vec![],
         None,
     );
     sm.set_x_google_ignore_list(vec![0]);
@@ -558,7 +558,7 @@ fn test_encode_all_sources_content_null() {
         None,
         vec!["a.js".into(), "b.js".into()],
         vec![None, None],
-        vec![].into_boxed_slice(),
+        vec![],
         None,
     );
     let json = sm.to_json_string();
@@ -576,7 +576,7 @@ fn test_encode_all_sources_content_null() {
         None,
         vec!["a.js".into(), "b.js".into()],
         vec![Some("content".into()), None],
-        vec![].into_boxed_slice(),
+        vec![],
         None,
     );
     let json = sm.to_json_string();
@@ -601,7 +601,7 @@ fn test_encode_escape_file_and_source_root() {
         Some("root\0path".into()),
         vec![],
         vec![],
-        vec![].into_boxed_slice(),
+        vec![],
         None,
     );
     let json = sm.to_json_string();

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -23,7 +23,7 @@ pub struct SourceMap<'a> {
     pub(crate) source_root: Option<Cow<'a, str>>,
     pub(crate) sources: Vec<Cow<'a, str>>,
     pub(crate) source_contents: Vec<Option<Cow<'a, str>>>,
-    pub(crate) tokens: Box<[Token]>,
+    pub(crate) tokens: Vec<Token>,
     pub(crate) token_chunks: Option<Vec<TokenChunk>>,
     /// Identifies third-party sources (such as framework code or bundler-generated code), allowing developers to avoid code that they don't want to see or step through, without having to configure this beforehand.
     /// The `x_google_ignoreList` field refers to the `sources` array, and lists the indices of all the known third-party sources in that source map.
@@ -39,7 +39,7 @@ impl<'a> SourceMap<'a> {
         source_root: Option<Cow<'a, str>>,
         sources: Vec<Cow<'a, str>>,
         source_contents: Vec<Option<Cow<'a, str>>>,
-        tokens: Box<[Token]>,
+        tokens: Vec<Token>,
         token_chunks: Option<Vec<TokenChunk>>,
     ) -> Self {
         Self {
@@ -302,7 +302,7 @@ pub struct SourceMapParts<'a> {
     pub source_root: Option<Cow<'a, str>>,
     pub sources: Vec<Cow<'a, str>>,
     pub source_contents: Vec<Option<Cow<'a, str>>>,
-    pub tokens: Box<[Token]>,
+    pub tokens: Vec<Token>,
     pub token_chunks: Option<Vec<TokenChunk>>,
     pub x_google_ignore_list: Option<Vec<u32>>,
     pub debug_id: Option<Cow<'a, str>>,
@@ -384,7 +384,7 @@ fn test_sourcemap_source_view_token() {
         None,
         vec![Cow::Borrowed("foo.js")],
         vec![],
-        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
+        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))],
         None,
     );
     let mut source_view_tokens = sm.get_source_view_tokens();

--- a/src/sourcemap_builder.rs
+++ b/src/sourcemap_builder.rs
@@ -98,7 +98,7 @@ impl SourceMapBuilder {
             None,
             self.sources,
             self.source_contents,
-            self.tokens.into_boxed_slice(),
+            self.tokens,
             self.token_chunks,
         )
     }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -28,8 +28,7 @@ fn invalid_token_position() {
             Token::new(0, 0, 0, 0, Some(0), None),
             Token::new(0, 10, 0, 0, Some(0), None),
             Token::new(0, 0, 0, 10, Some(0), None),
-        ]
-        .into_boxed_slice(),
+        ],
         None,
     );
     let js = "abc\ndef\n";


### PR DESCRIPTION
## Summary

`SourceMap::tokens` was `Box<[Token]>`, which forced `Vec::into_boxed_slice` at the end of `decode`, `decode_from_string`, `SourceMapBuilder::into_sourcemap`, and `ConcatSourceMapBuilder::into_sourcemap`. When the built-up `Vec<Token>`'s `len < capacity`, that conversion realloc-copies the buffer to its exact size. On parsed maps, the shrink-realloc was visible as a chunk of `_platform_memmove` samples in an Instruments Time Profile run against the decoder.

Keep `tokens` as `Vec<Token>` end-to-end. Drop the shrink-on-finalize realloc everywhere. Slight tail capacity stays in the final map and costs no time (just bytes of unused tail).

## Breaking changes

- `SourceMap::new` now takes `tokens: Vec<Token>` (was `Box<[Token]>`).
- `SourceMapParts::tokens` is now `Vec<Token>` (was `Box<[Token]>`).

Callers passing `tokens.into_boxed_slice()` should drop that conversion.

## Note

This is the foundation for #338 (decode hot-loop tightening). With `Vec<Token>` end-to-end, the decoder can over-allocate slightly without paying a realloc cost, which unlocks an unsafe-push fast path with a provable upper bound.