### PR TITLE
perf(decode): add `Token::new_raw` and use it in the hot loop

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -222,14 +222,10 @@ fn decode_mapping(mapping: &str, names_len: usize, sources_len: usize) -> Result
                     }
                 }
 
-                tokens.push(Token::new(
-                    dst_line,
-                    dst_col,
-                    src_line,
-                    src_col,
-                    if src == INVALID_ID { None } else { Some(src) },
-                    if name == INVALID_ID { None } else { Some(name) },
-                ));
+                // `src` / `name` already encode "absent" as `INVALID_ID`, so go
+                // through `Token::new_raw` to skip the `u32 → Option<u32> → u32`
+                // round-trip through `Token::new`.
+                tokens.push(Token::new_raw(dst_line, dst_col, src_line, src_col, src, name));
             }
         }
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -34,6 +34,22 @@ impl Token {
         }
     }
 
+    /// Construct a `Token` directly from raw u32 ids, using `INVALID_ID`
+    /// (`u32::MAX`) to mean "absent". Skips the `Option<u32> → u32`
+    /// roundtrip from [`Token::new`] for hot decode/concat loops that
+    /// already track the sentinel value directly.
+    #[inline]
+    pub(crate) fn new_raw(
+        dst_line: u32,
+        dst_col: u32,
+        src_line: u32,
+        src_col: u32,
+        source_id: u32,
+        name_id: u32,
+    ) -> Self {
+        Self { dst_line, dst_col, src_line, src_col, source_id, name_id }
+    }
+
     pub fn get_dst_line(&self) -> u32 {
         self.dst_line
     }


### PR DESCRIPTION
## Summary

`Token::new` takes `Option<u32>` for `source_id` / `name_id` and internally maps `None → INVALID_ID`. The decoder hot loop already tracks the absent value as `INVALID_ID` directly, so the call site has to wrap-then-unwrap:

```rust
tokens.push(Token::new(
    dst_line, dst_col, src_line, src_col,
    if src == INVALID_ID { None } else { Some(src) },
    if name == INVALID_ID { None } else { Some(name) },
));
```

Add a pub(crate) `Token::new_raw` that takes the raw u32 ids directly, and call it from `decode_mapping`. Saves two `Option<u32>` constructions and two `unwrap_or` per token.