### PR TITLE
clean up sourcemap internals

### DIFF
--- a/src/concat_sourcemap_builder.rs
+++ b/src/concat_sourcemap_builder.rs
@@ -140,23 +140,9 @@ impl<'a> ConcatSourceMapBuilder<'a> {
         // push advance the running prev-id state.
         let mut iter = sourcemap.get_tokens();
         if let Some(first) = iter.next() {
-            let source_id_offset = first.get_source_id().map(|x| x + source_offset);
-            let name_id_offset = first.get_name_id().map(|x| x + name_offset);
-            let new_token = Token::new(
-                first.get_dst_line() + line_offset,
-                first.get_dst_col(),
-                first.get_src_line(),
-                first.get_src_col(),
-                source_id_offset,
-                name_id_offset,
-            );
+            let new_token = translate_token(first, line_offset, source_offset, name_offset);
             if self.tokens.last() != Some(&new_token) {
-                if let Some(s) = source_id_offset {
-                    last_source_id = s;
-                }
-                if let Some(n) = name_id_offset {
-                    last_name_id = n;
-                }
+                update_prev_ids(new_token, &mut last_source_id, &mut last_name_id);
                 self.tokens.push(new_token);
             }
         }
@@ -165,22 +151,9 @@ impl<'a> ConcatSourceMapBuilder<'a> {
         // so the prev-id advance happens unconditionally for any token that
         // carries a source/name id.
         for token in iter {
-            let source_id_offset = token.get_source_id().map(|x| x + source_offset);
-            let name_id_offset = token.get_name_id().map(|x| x + name_offset);
-            if let Some(s) = source_id_offset {
-                last_source_id = s;
-            }
-            if let Some(n) = name_id_offset {
-                last_name_id = n;
-            }
-            self.tokens.push(Token::new(
-                token.get_dst_line() + line_offset,
-                token.get_dst_col(),
-                token.get_src_line(),
-                token.get_src_col(),
-                source_id_offset,
-                name_id_offset,
-            ));
+            let new_token = translate_token(token, line_offset, source_offset, name_offset);
+            update_prev_ids(new_token, &mut last_source_id, &mut last_name_id);
+            self.tokens.push(new_token);
         }
 
         // Flush the locals back to `self` so the next `add_sourcemap` call
@@ -220,6 +193,26 @@ impl<'a> ConcatSourceMapBuilder<'a> {
             self.tokens.into_boxed_slice(),
             Some(self.token_chunks),
         )
+    }
+}
+
+fn translate_token(token: Token, line_offset: u32, source_offset: u32, name_offset: u32) -> Token {
+    Token::new(
+        token.get_dst_line() + line_offset,
+        token.get_dst_col(),
+        token.get_src_line(),
+        token.get_src_col(),
+        token.get_source_id().map(|id| id + source_offset),
+        token.get_name_id().map(|id| id + name_offset),
+    )
+}
+
+fn update_prev_ids(token: Token, last_source_id: &mut u32, last_name_id: &mut u32) {
+    if let Some(source_id) = token.get_source_id() {
+        *last_source_id = source_id;
+    }
+    if let Some(name_id) = token.get_name_id() {
+        *last_name_id = name_id;
     }
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,5 +1,5 @@
 /// Port from https://github.com/getsentry/rust-sourcemap/blob/9.1.0/src/decoder.rs
-/// It is a helper for decode vlq soucemap string to `SourceMap`.
+/// It is a helper for decoding VLQ sourcemap strings to `SourceMap`.
 use std::borrow::Cow;
 
 use crate::error::{Error, Result};
@@ -50,14 +50,7 @@ where
 }
 
 pub fn decode(json: JSONSourceMap) -> Result<SourceMap<'static>> {
-    // Validate x_google_ignore_list indices
-    if let Some(ref ignore_list) = json.x_google_ignore_list {
-        for &idx in ignore_list {
-            if idx >= json.sources.len() as u32 {
-                return Err(Error::BadSourceReference(idx));
-            }
-        }
-    }
+    validate_x_google_ignore_list(json.x_google_ignore_list.as_deref(), json.sources.len())?;
 
     let tokens = decode_mapping(&json.mappings, json.names.len(), json.sources.len())?;
     Ok(SourceMap {
@@ -108,14 +101,7 @@ struct BorrowedJSONSourceMap<'a> {
 pub fn decode_from_string(value: &str) -> Result<SourceMap<'_>> {
     let json: BorrowedJSONSourceMap<'_> = serde_json::from_str(value)?;
 
-    // Validate x_google_ignore_list indices
-    if let Some(ref ignore_list) = json.x_google_ignore_list {
-        for &idx in ignore_list {
-            if idx >= json.sources.len() as u32 {
-                return Err(Error::BadSourceReference(idx));
-            }
-        }
-    }
+    validate_x_google_ignore_list(json.x_google_ignore_list.as_deref(), json.sources.len())?;
 
     let tokens = decode_mapping(&json.mappings, json.names.len(), json.sources.len())?;
 
@@ -130,6 +116,17 @@ pub fn decode_from_string(value: &str) -> Result<SourceMap<'_>> {
         x_google_ignore_list: json.x_google_ignore_list,
         debug_id: json.debug_id,
     })
+}
+
+fn validate_x_google_ignore_list(ignore_list: Option<&[u32]>, sources_len: usize) -> Result<()> {
+    if let Some(ignore_list) = ignore_list {
+        for &idx in ignore_list {
+            if idx as usize >= sources_len {
+                return Err(Error::BadSourceReference(idx));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn decode_mapping(mapping: &str, names_len: usize, sources_len: usize) -> Result<Vec<Token>> {
@@ -349,7 +346,7 @@ fn test_decode_sourcemap() {
 }
 
 #[test]
-fn test_decode_sourcemap_optional_filed() {
+fn test_decode_sourcemap_optional_field() {
     let input = r#"{
         "version": 3,
         "names": [],

--- a/src/token.rs
+++ b/src/token.rs
@@ -136,43 +136,27 @@ impl<'sm, 'data> SourceViewToken<'sm, 'data> {
     }
 
     pub fn get_name_id(&self) -> Option<u32> {
-        if self.token.name_id == INVALID_ID { None } else { Some(self.token.name_id) }
+        self.token.get_name_id()
     }
 
     pub fn get_source_id(&self) -> Option<u32> {
-        if self.token.source_id == INVALID_ID { None } else { Some(self.token.source_id) }
+        self.token.get_source_id()
     }
 
     pub fn get_name(&self) -> Option<&'sm str> {
-        if self.token.name_id == INVALID_ID {
-            None
-        } else {
-            self.sourcemap.get_name(self.token.name_id)
-        }
+        self.get_name_id().and_then(|id| self.sourcemap.get_name(id))
     }
 
     pub fn get_source(&self) -> Option<&'sm str> {
-        if self.token.source_id == INVALID_ID {
-            None
-        } else {
-            self.sourcemap.get_source(self.token.source_id)
-        }
+        self.get_source_id().and_then(|id| self.sourcemap.get_source(id))
     }
 
     pub fn get_source_content(&self) -> Option<&'sm str> {
-        if self.token.source_id == INVALID_ID {
-            None
-        } else {
-            self.sourcemap.get_source_content(self.token.source_id)
-        }
+        self.get_source_id().and_then(|id| self.sourcemap.get_source_content(id))
     }
 
     pub fn get_source_and_content(&self) -> Option<(&'sm str, &'sm str)> {
-        if self.token.source_id == INVALID_ID {
-            None
-        } else {
-            self.sourcemap.get_source_and_content(self.token.source_id)
-        }
+        self.get_source_id().and_then(|id| self.sourcemap.get_source_and_content(id))
     }
 
     pub fn to_tuple(&self) -> (Option<&'sm str>, u32, u32, Option<&'sm str>) {


### PR DESCRIPTION
## Summary

- Share `x_google_ignoreList` validation between owned and borrowed decode paths.
- Factor concat token translation and previous-id bookkeeping into small helpers.
- Delegate `SourceViewToken` accessors through `Token` getters to keep missing-id handling in one place.

## Impact

This is a behavior-preserving Rust cleanup that reduces duplicated logic and makes the existing token/source-map internals easier to follow.

## Validation

- `cargo fmt`
- `cargo test`
- `cargo clippy --all-targets --all-features`
- `typos`
