### PR TITLE
Revert "apply borrow builder pattern to ConcatSourceMapBuilder (#366)"

### DIFF
--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -4,10 +4,8 @@ use std::{
     time::Duration,
 };
 
-use std::borrow::Cow;
-
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use oxc_sourcemap::{ConcatSourceMapBuilder, SourceMap, SourceMapBuilder, Token};
+use oxc_sourcemap::{ConcatSourceMapBuilder, SourceMap, SourceMapBuilder};
 
 #[derive(Debug, Clone)]
 struct Fixture {
@@ -111,40 +109,8 @@ fn synthesize_xlarge(base_json: &str, repeats: usize) -> String {
     serde_json::to_string(&obj).unwrap()
 }
 
-/// Synthesize a chunk's worth of owned module sourcemaps, each carrying its full source text as
-/// `sourcesContent` — modelling rolldown's `SourceJoiner` inputs (the dominant concat workload).
-fn make_owned_module_maps(
-    count: usize,
-    content_bytes: usize,
-    tokens_per_map: u32,
-) -> Vec<(SourceMap<'static>, u32)> {
-    let line = "const value = computeSomething(alpha, beta, gamma); // source line\n";
-    let mut content = String::with_capacity(content_bytes + line.len());
-    while content.len() < content_bytes {
-        content.push_str(line);
-    }
-
-    let mut maps = Vec::with_capacity(count);
-    let mut line_offset = 0u32;
-    for i in 0..count {
-        let names = vec![Cow::Owned(format!("ident_a_{i}")), Cow::Owned(format!("ident_b_{i}"))];
-        let sources = vec![Cow::Owned(format!("src/module_{i}.js"))];
-        let source_contents = vec![Some(Cow::Owned(content.clone()))];
-        let tokens: Vec<Token> =
-            (0..tokens_per_map).map(|t| Token::new(t, t * 2, t, t, Some(0), Some(t % 2))).collect();
-        let map = SourceMap::new(
-            None,
-            names,
-            None,
-            sources,
-            source_contents,
-            tokens.into_boxed_slice(),
-            None,
-        );
-        maps.push((map, line_offset));
-        line_offset += tokens_per_map + 1;
-    }
-    maps
+fn token_line_span(sm: &SourceMap) -> u32 {
+    sm.get_tokens().last().map_or(1, |token| token.get_dst_line() + 1)
 }
 
 pub fn bench(c: &mut Criterion) {
@@ -242,34 +208,32 @@ pub fn bench(c: &mut Criterion) {
         });
     });
 
-    // A single representative concat workload: a chunk of 200 modules, each carrying ~2 KB of
-    // `sourcesContent`, concatenated into one owned `SourceMap` (rolldown's `SourceJoiner` shape).
-    let owned_maps = make_owned_module_maps(200, 2048, 100);
-    let content_bytes: u64 = owned_maps
-        .iter()
-        .map(|(map, _)| map.get_source_contents().flatten().map(str::len).sum::<usize>())
-        .sum::<usize>() as u64;
-    let concat_inputs: Vec<(&SourceMap, u32)> =
-        owned_maps.iter().map(|(map, offset)| (map, *offset)).collect();
+    let mut line_offset = 0u32;
+    let mut concat_input_size = 0u64;
+    let mut concat_inputs = Vec::with_capacity(parsed_fixtures.len());
+    for (_, bytes, sourcemap) in &parsed_fixtures {
+        concat_inputs.push((sourcemap, line_offset));
+        line_offset = line_offset.saturating_add(token_line_span(sourcemap));
+        concat_input_size += *bytes;
+    }
 
     let mut concat_group = c.benchmark_group("concat");
-    concat_group.throughput(Throughput::Bytes(content_bytes));
-    // Bulk constructor.
-    concat_group.bench_function("ConcatSourceMapBuilder::from_sourcemaps", |b| {
+    concat_group.throughput(Throughput::Bytes(concat_input_size));
+    concat_group.bench_function("from_sourcemaps", |b| {
         b.iter(|| {
-            let concat_sm = ConcatSourceMapBuilder::from_sourcemaps(black_box(&concat_inputs))
-                .into_owned_sourcemap();
+            let concat_sm =
+                ConcatSourceMapBuilder::from_sourcemaps(black_box(&concat_inputs)).into_sourcemap();
             black_box(concat_sm);
         });
     });
-    // Incremental adder (rolldown's `SourceJoiner` calls this per source).
-    concat_group.bench_function("ConcatSourceMapBuilder::add_sourcemap", |b| {
+    concat_group.bench_function("add_sourcemap_loop", |b| {
         b.iter(|| {
             let mut builder = ConcatSourceMapBuilder::default();
-            for &(map, offset) in black_box(&concat_inputs) {
-                builder.add_sourcemap(map, offset);
+            for &(sourcemap, line_offset) in black_box(&concat_inputs) {
+                builder.add_sourcemap(sourcemap, line_offset);
             }
-            black_box(builder.into_owned_sourcemap());
+            let concat_sm = builder.into_sourcemap();
+            black_box(concat_sm);
         });
     });
     concat_group.finish();

--- a/src/concat_sourcemap_builder.rs
+++ b/src/concat_sourcemap_builder.rs
@@ -4,21 +4,16 @@ use crate::{SourceMap, Token, token::TokenChunk};
 
 /// The `ConcatSourceMapBuilder` is a helper to concat sourcemaps.
 ///
-/// The builder **borrows** every name/source/sourcesContent string from the
-/// input source maps added via `add_sourcemap` / `from_sourcemaps` for its
-/// lifetime `'a` (it stores `&'a str`, not owned copies), so concatenation does
-/// no string allocations at all.
-///
-/// The ownership decision is deferred to the end:
-/// * [`into_sourcemap`](Self::into_sourcemap) returns a borrowed [`SourceMap<'a>`] — zero copy,
-///   and so cannot outlive its inputs.
-/// * [`into_owned_sourcemap`](Self::into_owned_sourcemap) copies the strings once into a
-///   `'static` [`crate::OwnedSourceMap`].
+/// The lifetime `'a` is the lifetime of the input source maps borrowed during
+/// `add_sourcemap` / `from_sourcemaps`: every name/source/sourcesContent
+/// string in the concatenated result is a [`Cow::Borrowed`] view into one of
+/// the input maps, so concatenation does no string allocations at all. The
+/// resulting [`SourceMap<'a>`] cannot outlive its inputs.
 #[derive(Debug, Default)]
 pub struct ConcatSourceMapBuilder<'a> {
-    pub(crate) names: Vec<&'a str>,
-    pub(crate) sources: Vec<&'a str>,
-    pub(crate) source_contents: Vec<Option<&'a str>>,
+    pub(crate) names: Vec<Cow<'a, str>>,
+    pub(crate) sources: Vec<Cow<'a, str>>,
+    pub(crate) source_contents: Vec<Option<Cow<'a, str>>>,
     pub(crate) tokens: Vec<Token>,
     /// The `token_chunks` is used for encode tokens to vlq mappings at parallel.
     pub(crate) token_chunks: Vec<TokenChunk>,
@@ -104,10 +99,11 @@ impl<'a> ConcatSourceMapBuilder<'a> {
         // Borrow strings directly from the input map — no allocations.
         // The output `SourceMap`'s lifetime is tied to `'a`, so the
         // borrow checker enforces that input maps outlive it.
-        self.sources.extend(sourcemap.get_sources());
-        self.source_contents.extend(sourcemap.get_source_contents());
+        self.sources.extend(sourcemap.get_sources().map(Cow::Borrowed));
+        self.source_contents
+            .extend(sourcemap.get_source_contents().map(|opt| opt.map(Cow::Borrowed)));
         self.names.reserve(sourcemap.names.len());
-        self.names.extend(sourcemap.get_names());
+        self.names.extend(sourcemap.get_names().map(Cow::Borrowed));
 
         // Append every input token to `self.tokens`, translated by `line_offset`,
         // `source_offset`, and `name_offset` so its references resolve against
@@ -187,35 +183,16 @@ impl<'a> ConcatSourceMapBuilder<'a> {
         }
     }
 
-    /// Finish, borrowing the names/sources/contents for `'a` (zero copy).
     pub fn into_sourcemap(self) -> SourceMap<'a> {
         SourceMap::new(
             None,
-            self.names.into_iter().map(Cow::Borrowed).collect(),
+            self.names,
             None,
-            self.sources.into_iter().map(Cow::Borrowed).collect(),
-            self.source_contents.into_iter().map(|content| content.map(Cow::Borrowed)).collect(),
+            self.sources,
+            self.source_contents,
             self.tokens.into_boxed_slice(),
             Some(self.token_chunks),
         )
-    }
-
-    /// Same as [`Self::into_sourcemap`], but copies the strings once into an owned
-    /// [`crate::OwnedSourceMap`] so callers can store the result without spelling out `'static`.
-    #[inline]
-    pub fn into_owned_sourcemap(self) -> crate::OwnedSourceMap {
-        crate::OwnedSourceMap::new(SourceMap::new(
-            None,
-            self.names.into_iter().map(|name| Cow::Owned(name.to_owned())).collect(),
-            None,
-            self.sources.into_iter().map(|source| Cow::Owned(source.to_owned())).collect(),
-            self.source_contents
-                .into_iter()
-                .map(|content| content.map(|content| Cow::Owned(content.to_owned())))
-                .collect(),
-            self.tokens.into_boxed_slice(),
-            Some(self.token_chunks),
-        ))
     }
 }
 


### PR DESCRIPTION
Reverts #366 (and #369, which sits on top of it).

#366 switched `ConcatSourceMapBuilder` to borrowed `&'a str` storage — optimal when the input maps outlive the result. But the builder's main consumer, rolldown's `SourceJoiner`, feeds **owned** `SourceMap<'static>` maps and wants an owned map back. The right optimization there is owned-merge — *move* the owned strings into the builder (no copy) — which needs `Cow` storage, not `&str`.

This restores the original `Cow<'a, str>` storage so the owned-merge work can land on top (#368, mirroring the approach in #365). #369's benchmark is reverted alongside because it calls `ConcatSourceMapBuilder::into_owned_sourcemap` (added by #366); #368 reintroduces a superset of those benches on the restored storage.