### PR TITLE
test: clean up tests and reach full coverage

### DIFF
--- a/src/concat_sourcemap_builder.rs
+++ b/src/concat_sourcemap_builder.rs
@@ -282,252 +282,293 @@ impl<'a> ConcatSourceMapBuilder<'a> {
 }
 
 #[cfg(test)]
-fn build_test_inputs() -> [SourceMap<'static>; 3] {
-    [
-        SourceMap::new(
-            None,
-            vec![Cow::Borrowed("foo"), Cow::Borrowed("foo2")],
-            None,
-            vec![Cow::Borrowed("foo.js")],
-            vec![],
-            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
-            None,
-        ),
-        SourceMap::new(
-            None,
-            vec![Cow::Borrowed("bar")],
-            None,
-            vec![Cow::Borrowed("bar.js")],
-            vec![],
-            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
-            None,
-        ),
-        SourceMap::new(
-            None,
-            vec![Cow::Borrowed("abc")],
-            None,
-            vec![Cow::Borrowed("abc.js")],
-            vec![],
-            vec![Token::new(1, 2, 2, 2, Some(0), Some(0))].into_boxed_slice(),
-            None,
-        ),
-    ]
-}
+mod tests {
+    use super::*;
 
-#[cfg(test)]
-fn assert_test_result(concat_sm: SourceMap<'_>) {
-    let expected = SourceMap::new(
-        None,
-        vec![
-            Cow::Borrowed("foo"),
-            Cow::Borrowed("foo2"),
-            Cow::Borrowed("bar"),
-            Cow::Borrowed("abc"),
-        ],
-        None,
-        vec![Cow::Borrowed("foo.js"), Cow::Borrowed("bar.js"), Cow::Borrowed("abc.js")],
-        vec![],
-        vec![
-            Token::new(1, 1, 1, 1, Some(0), Some(0)),
-            Token::new(3, 1, 1, 1, Some(1), Some(2)),
-            Token::new(3, 2, 2, 2, Some(2), Some(3)),
+    fn build_test_inputs() -> [SourceMap<'static>; 3] {
+        [
+            SourceMap::new(
+                None,
+                vec![Cow::Borrowed("foo"), Cow::Borrowed("foo2")],
+                None,
+                vec![Cow::Borrowed("foo.js")],
+                vec![],
+                vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
+                None,
+            ),
+            SourceMap::new(
+                None,
+                vec![Cow::Borrowed("bar")],
+                None,
+                vec![Cow::Borrowed("bar.js")],
+                vec![],
+                vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
+                None,
+            ),
+            SourceMap::new(
+                None,
+                vec![Cow::Borrowed("abc")],
+                None,
+                vec![Cow::Borrowed("abc.js")],
+                vec![],
+                vec![Token::new(1, 2, 2, 2, Some(0), Some(0))].into_boxed_slice(),
+                None,
+            ),
         ]
-        .into_boxed_slice(),
-        None,
-    );
-
-    assert_eq!(concat_sm.tokens, expected.tokens);
-    assert_eq!(concat_sm.sources, expected.sources);
-    assert_eq!(concat_sm.names, expected.names);
-    assert_eq!(
-        concat_sm.token_chunks,
-        Some(vec![
-            TokenChunk::new(0, 1, 0, 0, 0, 0, 0, 0,),
-            TokenChunk::new(1, 2, 1, 1, 1, 1, 0, 0,),
-            TokenChunk::new(2, 3, 3, 1, 1, 1, 2, 1,)
-        ])
-    );
-
-    assert_eq!(expected.to_json().mappings, concat_sm.to_json().mappings);
-}
-
-#[test]
-fn test_concat_sourcemap_builder() {
-    let [sm1, sm2, sm3] = build_test_inputs();
-    let inputs = [(&sm1, 0u32), (&sm2, 2), (&sm3, 2)];
-    let mut builder = ConcatSourceMapBuilder::default();
-    for (sourcemap, line_offset) in inputs.iter().copied() {
-        builder.add_sourcemap(sourcemap, line_offset);
     }
-    assert_test_result(builder.into_sourcemap());
-}
 
-#[test]
-fn test_concat_sourcemap_builder_from_sourcemaps() {
-    let [sm1, sm2, sm3] = build_test_inputs();
-    let builder = ConcatSourceMapBuilder::from_sourcemaps(&[(&sm1, 0), (&sm2, 2), (&sm3, 2)]);
-    assert_test_result(builder.into_sourcemap());
-}
-
-#[test]
-fn test_concat_sourcemap_builder_add_sourcemap_owned() {
-    // Moving owned maps in must produce the same result as borrowing them.
-    let [sm1, sm2, sm3] = build_test_inputs();
-    let mut builder = ConcatSourceMapBuilder::default();
-    builder.add_sourcemap_owned(sm1, 0);
-    builder.add_sourcemap_owned(sm2, 2);
-    builder.add_sourcemap_owned(sm3, 2);
-    assert_test_result(builder.into_sourcemap());
-}
-
-#[test]
-fn test_concat_sourcemap_builder_from_owned_sourcemaps() {
-    let [sm1, sm2, sm3] = build_test_inputs();
-    let builder = ConcatSourceMapBuilder::from_owned_sourcemaps(vec![(sm1, 0), (sm2, 2), (sm3, 2)]);
-    assert_test_result(builder.into_sourcemap());
-}
-
-#[test]
-fn test_concat_owned_moves_strings_into_owned_sourcemap() {
-    // Two owned maps with owned content; the move-in path must preserve every string and
-    // renumber `other`'s ids/lines, ending up as a `'static` map with no data lost.
-    let a = SourceMap::new(
-        None,
-        vec![Cow::Owned("name_a".to_string())],
-        None,
-        vec![Cow::Owned("a.js".to_string())],
-        vec![Some(Cow::Owned("a content".to_string()))],
-        vec![Token::new(0, 0, 0, 0, Some(0), Some(0))].into_boxed_slice(),
-        None,
-    );
-    let b = SourceMap::new(
-        None,
-        vec![Cow::Owned("name_b".to_string())],
-        None,
-        vec![Cow::Owned("b.js".to_string())],
-        vec![Some(Cow::Owned("b content".to_string()))],
-        vec![Token::new(0, 0, 0, 0, Some(0), Some(0))].into_boxed_slice(),
-        None,
-    );
-
-    let owned =
-        ConcatSourceMapBuilder::from_owned_sourcemaps(vec![(a, 0), (b, 5)]).into_owned_sourcemap();
-
-    assert_eq!(owned.get_sources().collect::<Vec<_>>(), vec!["a.js", "b.js"]);
-    assert_eq!(owned.get_names().collect::<Vec<_>>(), vec!["name_a", "name_b"]);
-    assert_eq!(owned.get_source_content(0), Some("a content"));
-    assert_eq!(owned.get_source_content(1), Some("b content"));
-    // `b`'s token is shifted by the line offset and renumbered onto the combined ids.
-    assert_eq!(owned.get_token(1), Some(Token::new(5, 0, 0, 0, Some(1), Some(1))));
-}
-
-#[test]
-fn test_concat_owned_translates_after_tokenless_map() {
-    // A first map that contributes a source but no tokens leaves `self.tokens` empty while the
-    // source offset advances; the next map must still renumber its ids (not take the memcpy path).
-    let tokenless = SourceMap::new(
-        None,
-        vec![],
-        None,
-        vec![Cow::Owned("a.js".to_string())],
-        vec![Some(Cow::Owned("a content".to_string()))],
-        vec![].into_boxed_slice(),
-        None,
-    );
-    let with_token = SourceMap::new(
-        None,
-        vec![],
-        None,
-        vec![Cow::Owned("b.js".to_string())],
-        vec![Some(Cow::Owned("b content".to_string()))],
-        // Source id 0 within its own map; after concat it must point at "b.js" (combined index 1).
-        vec![Token::new(0, 0, 0, 0, Some(0), None)].into_boxed_slice(),
-        None,
-    );
-
-    let map = ConcatSourceMapBuilder::from_owned_sourcemaps(vec![(tokenless, 0), (with_token, 0)])
-        .into_sourcemap();
-
-    assert_eq!(map.get_sources().collect::<Vec<_>>(), vec!["a.js", "b.js"]);
-    assert_eq!(map.get_token(0).unwrap().get_source_id(), Some(1));
-    assert_eq!(map.get_source_content(1), Some("b content"));
-}
-
-#[test]
-fn test_concat_owned_pads_missing_source_contents() {
-    // First map has a source but no `sourcesContent`; the second map's content must stay attached
-    // to its own source rather than shifting onto the first map's source id.
-    let no_content = SourceMap::new(
-        None,
-        vec![],
-        None,
-        vec![Cow::Owned("a.js".to_string())],
-        vec![],
-        vec![Token::new(0, 0, 0, 0, Some(0), None)].into_boxed_slice(),
-        None,
-    );
-    let with_content = SourceMap::new(
-        None,
-        vec![],
-        None,
-        vec![Cow::Owned("b.js".to_string())],
-        vec![Some(Cow::Owned("b content".to_string()))],
-        vec![Token::new(0, 0, 0, 0, Some(0), None)].into_boxed_slice(),
-        None,
-    );
-
-    let map =
-        ConcatSourceMapBuilder::from_owned_sourcemaps(vec![(no_content, 0), (with_content, 1)])
-            .into_sourcemap();
-
-    assert_eq!(map.get_sources().collect::<Vec<_>>(), vec!["a.js", "b.js"]);
-    assert_eq!(map.get_source_content(0), None);
-    assert_eq!(map.get_source_content(1), Some("b content"));
-}
-
-#[test]
-fn test_concat_sourcemap_builder_deduplicates_tokens() {
-    // Test that duplicate tokens at concatenation boundaries are removed
-    // For tokens to be truly identical after concatenation, they must have:
-    // - Same dst_line (after line_offset)
-    // - Same dst_col
-    // - Same src_line, src_col
-    // - Same source_id and name_id (after source_offset/name_offset)
-
-    // This is difficult to create naturally, so we test the scenario where
-    // no deduplication should happen (tokens are different)
-    let sm1 = SourceMap::new(
-        None,
-        vec![Cow::Borrowed("name1")],
-        None,
-        vec![Cow::Borrowed("file1.js")],
-        vec![],
-        vec![Token::new(1, 1, 1, 1, Some(0), Some(0)), Token::new(2, 5, 2, 5, Some(0), Some(0))]
+    fn assert_test_result(concat_sm: SourceMap<'_>) {
+        let expected = SourceMap::new(
+            None,
+            vec![
+                Cow::Borrowed("foo"),
+                Cow::Borrowed("foo2"),
+                Cow::Borrowed("bar"),
+                Cow::Borrowed("abc"),
+            ],
+            None,
+            vec![Cow::Borrowed("foo.js"), Cow::Borrowed("bar.js"), Cow::Borrowed("abc.js")],
+            vec![],
+            vec![
+                Token::new(1, 1, 1, 1, Some(0), Some(0)),
+                Token::new(3, 1, 1, 1, Some(1), Some(2)),
+                Token::new(3, 2, 2, 2, Some(2), Some(3)),
+            ]
             .into_boxed_slice(),
-        None,
-    );
+            None,
+        );
 
-    // sm2 has different source_id/name_id after offset, so won't deduplicate
-    let sm2 = SourceMap::new(
-        None,
-        vec![Cow::Borrowed("name2")],
-        None,
-        vec![Cow::Borrowed("file2.js")],
-        vec![],
-        vec![
-            Token::new(2, 5, 2, 5, Some(0), Some(0)), // Different source/name after offset
-            Token::new(3, 10, 3, 10, Some(0), Some(0)),
-        ]
-        .into_boxed_slice(),
-        None,
-    );
+        assert_eq!(concat_sm.tokens, expected.tokens);
+        assert_eq!(concat_sm.sources, expected.sources);
+        assert_eq!(concat_sm.names, expected.names);
+        assert_eq!(
+            concat_sm.token_chunks,
+            Some(vec![
+                TokenChunk::new(0, 1, 0, 0, 0, 0, 0, 0,),
+                TokenChunk::new(1, 2, 1, 1, 1, 1, 0, 0,),
+                TokenChunk::new(2, 3, 3, 1, 1, 1, 2, 1,)
+            ])
+        );
 
-    let mut builder = ConcatSourceMapBuilder::default();
-    builder.add_sourcemap(&sm1, 0);
-    builder.add_sourcemap(&sm2, 0);
+        assert_eq!(expected.to_json().mappings, concat_sm.to_json().mappings);
+    }
 
-    let concat_sm = builder.into_sourcemap();
+    #[test]
+    fn add_sourcemap_in_loop() {
+        let [sm1, sm2, sm3] = build_test_inputs();
+        let inputs = [(&sm1, 0u32), (&sm2, 2), (&sm3, 2)];
+        let mut builder = ConcatSourceMapBuilder::default();
+        for (sourcemap, line_offset) in inputs.iter().copied() {
+            builder.add_sourcemap(sourcemap, line_offset);
+        }
+        assert_test_result(builder.into_sourcemap());
+    }
 
-    // Should have 4 tokens (no deduplication because source_id/name_id differ)
-    assert_eq!(concat_sm.tokens.len(), 4);
+    #[test]
+    fn from_sourcemaps() {
+        let [sm1, sm2, sm3] = build_test_inputs();
+        let builder = ConcatSourceMapBuilder::from_sourcemaps(&[(&sm1, 0), (&sm2, 2), (&sm3, 2)]);
+        assert_test_result(builder.into_sourcemap());
+    }
+
+    #[test]
+    fn add_sourcemap_owned() {
+        // Moving owned maps in must produce the same result as borrowing them.
+        let [sm1, sm2, sm3] = build_test_inputs();
+        let mut builder = ConcatSourceMapBuilder::default();
+        builder.add_sourcemap_owned(sm1, 0);
+        builder.add_sourcemap_owned(sm2, 2);
+        builder.add_sourcemap_owned(sm3, 2);
+        assert_test_result(builder.into_sourcemap());
+    }
+
+    #[test]
+    fn from_owned_sourcemaps() {
+        let [sm1, sm2, sm3] = build_test_inputs();
+        let builder =
+            ConcatSourceMapBuilder::from_owned_sourcemaps(vec![(sm1, 0), (sm2, 2), (sm3, 2)]);
+        assert_test_result(builder.into_sourcemap());
+    }
+
+    #[test]
+    fn owned_moves_strings_into_owned_sourcemap() {
+        // Two owned maps with owned content; the move-in path must preserve every string and
+        // renumber `other`'s ids/lines, ending up as a `'static` map with no data lost.
+        let a = SourceMap::new(
+            None,
+            vec![Cow::Owned("name_a".to_string())],
+            None,
+            vec![Cow::Owned("a.js".to_string())],
+            vec![Some(Cow::Owned("a content".to_string()))],
+            vec![Token::new(0, 0, 0, 0, Some(0), Some(0))].into_boxed_slice(),
+            None,
+        );
+        let b = SourceMap::new(
+            None,
+            vec![Cow::Owned("name_b".to_string())],
+            None,
+            vec![Cow::Owned("b.js".to_string())],
+            vec![Some(Cow::Owned("b content".to_string()))],
+            vec![Token::new(0, 0, 0, 0, Some(0), Some(0))].into_boxed_slice(),
+            None,
+        );
+
+        let owned = ConcatSourceMapBuilder::from_owned_sourcemaps(vec![(a, 0), (b, 5)])
+            .into_owned_sourcemap();
+
+        assert_eq!(owned.get_sources().collect::<Vec<_>>(), vec!["a.js", "b.js"]);
+        assert_eq!(owned.get_names().collect::<Vec<_>>(), vec!["name_a", "name_b"]);
+        assert_eq!(owned.get_source_content(0), Some("a content"));
+        assert_eq!(owned.get_source_content(1), Some("b content"));
+        // `b`'s token is shifted by the line offset and renumbered onto the combined ids.
+        assert_eq!(owned.get_token(1), Some(Token::new(5, 0, 0, 0, Some(1), Some(1))));
+    }
+
+    #[test]
+    fn owned_translates_after_tokenless_map() {
+        // A first map that contributes a source but no tokens leaves `self.tokens` empty while the
+        // source offset advances; the next map must still renumber its ids (not take the memcpy path).
+        let tokenless = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Owned("a.js".to_string())],
+            vec![Some(Cow::Owned("a content".to_string()))],
+            vec![].into_boxed_slice(),
+            None,
+        );
+        let with_token = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Owned("b.js".to_string())],
+            vec![Some(Cow::Owned("b content".to_string()))],
+            // Source id 0 within its own map; after concat it must point at "b.js" (combined index 1).
+            vec![Token::new(0, 0, 0, 0, Some(0), None)].into_boxed_slice(),
+            None,
+        );
+
+        let map =
+            ConcatSourceMapBuilder::from_owned_sourcemaps(vec![(tokenless, 0), (with_token, 0)])
+                .into_sourcemap();
+
+        assert_eq!(map.get_sources().collect::<Vec<_>>(), vec!["a.js", "b.js"]);
+        assert_eq!(map.get_token(0).unwrap().get_source_id(), Some(1));
+        assert_eq!(map.get_source_content(1), Some("b content"));
+    }
+
+    #[test]
+    fn owned_pads_missing_source_contents() {
+        // First map has a source but no `sourcesContent`; the second map's content must stay attached
+        // to its own source rather than shifting onto the first map's source id.
+        let no_content = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Owned("a.js".to_string())],
+            vec![],
+            vec![Token::new(0, 0, 0, 0, Some(0), None)].into_boxed_slice(),
+            None,
+        );
+        let with_content = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Owned("b.js".to_string())],
+            vec![Some(Cow::Owned("b content".to_string()))],
+            vec![Token::new(0, 0, 0, 0, Some(0), None)].into_boxed_slice(),
+            None,
+        );
+
+        let map =
+            ConcatSourceMapBuilder::from_owned_sourcemaps(vec![(no_content, 0), (with_content, 1)])
+                .into_sourcemap();
+
+        assert_eq!(map.get_sources().collect::<Vec<_>>(), vec!["a.js", "b.js"]);
+        assert_eq!(map.get_source_content(0), None);
+        assert_eq!(map.get_source_content(1), Some("b content"));
+    }
+
+    #[test]
+    fn keeps_distinct_boundary_tokens() {
+        // Boundary dedup only drops a token when it is *identical* to the
+        // previous map's last token (same dst/src position and source/name id
+        // after offsetting). Here the seam tokens differ, so nothing is
+        // dropped — the counterpart to `dedups_identical_boundary_token`.
+        let sm1 = SourceMap::new(
+            None,
+            vec![Cow::Borrowed("name1")],
+            None,
+            vec![Cow::Borrowed("file1.js")],
+            vec![],
+            vec![
+                Token::new(1, 1, 1, 1, Some(0), Some(0)),
+                Token::new(2, 5, 2, 5, Some(0), Some(0)),
+            ]
+            .into_boxed_slice(),
+            None,
+        );
+
+        // sm2 has different source_id/name_id after offset, so won't deduplicate
+        let sm2 = SourceMap::new(
+            None,
+            vec![Cow::Borrowed("name2")],
+            None,
+            vec![Cow::Borrowed("file2.js")],
+            vec![],
+            vec![
+                Token::new(2, 5, 2, 5, Some(0), Some(0)), // Different source/name after offset
+                Token::new(3, 10, 3, 10, Some(0), Some(0)),
+            ]
+            .into_boxed_slice(),
+            None,
+        );
+
+        let mut builder = ConcatSourceMapBuilder::default();
+        builder.add_sourcemap(&sm1, 0);
+        builder.add_sourcemap(&sm2, 0);
+
+        let concat_sm = builder.into_sourcemap();
+
+        // Should have 4 tokens (no deduplication because source_id/name_id differ)
+        assert_eq!(concat_sm.tokens.len(), 4);
+    }
+
+    #[test]
+    fn dedups_identical_boundary_token() {
+        // When the second map contributes no sources/names, its first token can
+        // translate to exactly the first map's last token. The boundary dedup
+        // must then drop the duplicate rather than emit it twice.
+        let map1 = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![],
+            vec![],
+            vec![Token::new(0, 0, 0, 0, None, None), Token::new(2, 3, 0, 0, None, None)]
+                .into_boxed_slice(),
+            None,
+        );
+        let map2 = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![],
+            vec![],
+            vec![Token::new(0, 3, 0, 0, None, None), Token::new(1, 9, 0, 0, None, None)]
+                .into_boxed_slice(),
+            None,
+        );
+
+        let mut builder = ConcatSourceMapBuilder::default();
+        builder.add_sourcemap(&map1, 0);
+        // `map2`'s first token shifted by `line_offset` 2 equals `map1`'s last token.
+        builder.add_sourcemap(&map2, 2);
+        let concat_sm = builder.into_sourcemap();
+
+        // 2 from map1 + 1 from map2 (its first token was deduplicated at the seam).
+        assert_eq!(concat_sm.tokens.len(), 3);
+        assert_eq!(concat_sm.tokens[1], Token::new(2, 3, 0, 0, None, None));
+        assert_eq!(concat_sm.tokens[2], Token::new(3, 9, 0, 0, None, None));
+    }
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -284,18 +284,14 @@ fn parse_vlq_segment_into(mapping: &[u8], cursor: &mut usize, rv: &mut [i64; 5])
         let val = enc & 0b11111;
         let cont = enc >> 5;
 
-        // Check if shift would overflow before applying
-        if shift >= 64 {
+        // VLQ shift grows by 5 bits per continuation byte. Bail out before
+        // `val << shift` could overflow i64: the largest safe shift for a 5-bit
+        // value is 62, and `shift` only ever takes multiples of 5, so the first
+        // offending shift is 65.
+        if shift > 62 {
             return Err(Error::VlqOverflow);
         }
-
-        // For large shifts, check if the value would fit in 32 bits when decoded
-        if shift <= 62 {
-            cur = cur.wrapping_add(val << shift);
-        } else {
-            // Beyond 62 bits of shift, we'd overflow i64
-            return Err(Error::VlqOverflow);
-        }
+        cur = cur.wrapping_add(val << shift);
 
         *cursor += 1;
         shift += 5;
@@ -325,62 +321,167 @@ fn parse_vlq_segment_into(mapping: &[u8], cursor: &mut usize, rv: &mut [i64; 5])
     }
 }
 
-#[test]
-fn test_decode_sourcemap() {
-    let input = r#"{
-        "version": 3,
-        "sources": ["coolstuff.js"],
-        "sourceRoot": "x",
-        "names": ["x","alert"],
-        "mappings": "AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM",
-        "x_google_ignoreList": [0]
-    }"#;
-    let sm = SourceMap::from_json_string(input).unwrap();
-    assert_eq!(sm.get_source_root(), Some("x"));
-    assert_eq!(sm.get_x_google_ignore_list(), Some(&[0][..]));
-    let mut iter = sm.get_source_view_tokens().filter(|token| token.get_name_id().is_some());
-    assert_eq!(iter.next().unwrap().to_tuple(), (Some("coolstuff.js"), 0, 4, Some("x")));
-    assert_eq!(iter.next().unwrap().to_tuple(), (Some("coolstuff.js"), 1, 4, Some("x")));
-    assert_eq!(iter.next().unwrap().to_tuple(), (Some("coolstuff.js"), 2, 2, Some("alert")));
-    assert!(iter.next().is_none());
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_decode_sourcemap_optional_field() {
-    let input = r#"{
-        "version": 3,
-        "names": [],
-        "sources": [],
-        "sourcesContent": [null],
-        "mappings": ""
-    }"#;
-    SourceMap::from_json_string(input).expect("should success");
-}
+    #[test]
+    fn decode_sourcemap() {
+        let input = r#"{
+            "version": 3,
+            "sources": ["coolstuff.js"],
+            "sourceRoot": "x",
+            "names": ["x","alert"],
+            "mappings": "AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM",
+            "x_google_ignoreList": [0]
+        }"#;
+        let sm = SourceMap::from_json_string(input).unwrap();
+        assert_eq!(sm.get_source_root(), Some("x"));
+        assert_eq!(sm.get_x_google_ignore_list(), Some(&[0][..]));
+        let mut iter = sm.get_source_view_tokens().filter(|token| token.get_name_id().is_some());
+        assert_eq!(iter.next().unwrap().to_tuple(), (Some("coolstuff.js"), 0, 4, Some("x")));
+        assert_eq!(iter.next().unwrap().to_tuple(), (Some("coolstuff.js"), 1, 4, Some("x")));
+        assert_eq!(iter.next().unwrap().to_tuple(), (Some("coolstuff.js"), 2, 2, Some("alert")));
+        assert!(iter.next().is_none());
+    }
 
-#[test]
-fn test_decode_mapping_bad_segment_size() {
-    let input = r#"{
-        "version": 3,
-        "names": [],
-        "sources": [],
-        "sourcesContent": [],
-        "mappings": "AA"
-    }"#;
+    #[test]
+    fn decode_from_json_value() {
+        // `SourceMap::from_json` / `decode` consumes an owned `JSONSourceMap`,
+        // a separate path from the borrowed `from_json_string` / `decode_from_string`.
+        let json = SourceMap::from_json_string(
+            r#"{
+                "version": 3,
+                "file": "f.js",
+                "sourceRoot": "r",
+                "names": ["n"],
+                "sources": ["a.js"],
+                "sourcesContent": ["c"],
+                "mappings": "AAAAA",
+                "debugId": "d",
+                "x_google_ignoreList": [0]
+            }"#,
+        )
+        .unwrap()
+        .to_json();
+        let sm = SourceMap::from_json(json).unwrap();
+        assert_eq!(sm.get_file(), Some("f.js"));
+        assert_eq!(sm.get_source_root(), Some("r"));
+        assert_eq!(sm.get_debug_id(), Some("d"));
+        assert_eq!(sm.get_x_google_ignore_list(), Some(&[0][..]));
+        assert_eq!(sm.get_source_content(0), Some("c"));
+        assert_eq!(sm.get_name(0), Some("n"));
+    }
 
-    let err = SourceMap::from_json_string(input).unwrap_err();
-    assert!(matches!(err, Error::BadSegmentSize(2)));
-}
+    #[test]
+    fn decode_sourcemap_optional_field() {
+        let input = r#"{
+            "version": 3,
+            "names": [],
+            "sources": [],
+            "sourcesContent": [null],
+            "mappings": ""
+        }"#;
+        SourceMap::from_json_string(input).expect("should success");
+    }
 
-#[test]
-fn test_decode_mapping_vlq_leftover() {
-    let input = r#"{
-        "version": 3,
-        "names": [],
-        "sources": [],
-        "sourcesContent": [],
-        "mappings": "g"
-    }"#;
+    #[test]
+    fn decode_unsupported_version() {
+        let input = r#"{"version": 2, "names": [], "sources": [], "mappings": ""}"#;
+        let err = SourceMap::from_json_string(input).unwrap_err();
+        assert!(matches!(err, Error::BadJson(_)));
+    }
 
-    let err = SourceMap::from_json_string(input).unwrap_err();
-    assert!(matches!(err, Error::VlqLeftover));
+    #[test]
+    fn decode_mapping_bad_segment_size() {
+        let input = r#"{"version":3,"names":[],"sources":[],"sourcesContent":[],"mappings":"AA"}"#;
+        let err = SourceMap::from_json_string(input).unwrap_err();
+        assert!(matches!(err, Error::BadSegmentSize(2)));
+    }
+
+    #[test]
+    fn decode_mapping_vlq_leftover() {
+        let input = r#"{"version":3,"names":[],"sources":[],"sourcesContent":[],"mappings":"g"}"#;
+        let err = SourceMap::from_json_string(input).unwrap_err();
+        assert!(matches!(err, Error::VlqLeftover));
+    }
+
+    #[test]
+    fn decode_mapping_vlq_overflow() {
+        // A long run of continuation bytes overflows the VLQ shift accumulator.
+        let mappings = "g".repeat(14);
+        let input =
+            format!(r#"{{"version":3,"names":[],"sources":["a.js"],"mappings":"{mappings}"}}"#);
+        let err = SourceMap::from_json_string(&input).unwrap_err();
+        assert!(matches!(err, Error::VlqOverflow));
+    }
+
+    #[test]
+    fn decode_mapping_bad_source_reference() {
+        // 4-field segment references source id 0, but there are no sources.
+        let input = r#"{"version":3,"names":[],"sources":[],"mappings":"AAAA"}"#;
+        let err = SourceMap::from_json_string(input).unwrap_err();
+        assert!(matches!(err, Error::BadSourceReference(_)));
+    }
+
+    #[test]
+    fn decode_mapping_bad_name_reference() {
+        // 5-field segment references name id 0, but there are no names.
+        let input = r#"{"version":3,"names":[],"sources":["a.js"],"mappings":"AAAAA"}"#;
+        let err = SourceMap::from_json_string(input).unwrap_err();
+        assert!(matches!(err, Error::BadNameReference(0)));
+    }
+
+    #[test]
+    fn decode_ignore_list_bad_source_reference() {
+        // `x_google_ignoreList` references a source index that does not exist.
+        let input =
+            r#"{"version":3,"names":[],"sources":[],"mappings":"","x_google_ignoreList":[3]}"#;
+        let err = SourceMap::from_json_string(input).unwrap_err();
+        assert!(matches!(err, Error::BadSourceReference(3)));
+    }
+
+    #[test]
+    fn decode_owned_propagates_errors() {
+        // The owned `decode` path (`SourceMap::from_json`) must surface the same
+        // validation errors as the borrowed path: a bad ignore-list index...
+        let bad_ignore_list = JSONSourceMap {
+            version: 3,
+            file: None,
+            mappings: String::new(),
+            source_root: None,
+            sources: vec![],
+            sources_content: None,
+            names: vec![],
+            debug_id: None,
+            x_google_ignore_list: Some(vec![3]),
+        };
+        assert!(matches!(SourceMap::from_json(bad_ignore_list), Err(Error::BadSourceReference(3))));
+
+        // ...and a mapping that references a source with no sources declared.
+        let bad_mapping = JSONSourceMap {
+            version: 3,
+            file: None,
+            mappings: "AAAA".to_string(),
+            source_root: None,
+            sources: vec![],
+            sources_content: None,
+            names: vec![],
+            debug_id: None,
+            x_google_ignore_list: None,
+        };
+        assert!(matches!(SourceMap::from_json(bad_mapping), Err(Error::BadSourceReference(_))));
+    }
+
+    #[test]
+    fn parse_vlq_segment_empty_is_no_values() {
+        // Directly exercise the defensive `VlqNoValues` branch: with the cursor
+        // already at the end of the input, no values can be decoded. This state
+        // is unreachable through `decode_mapping` (which only calls the parser
+        // on a non-delimiter byte), so it is covered here.
+        let mut cursor = 0;
+        let mut out = [0i64; 5];
+        let err = parse_vlq_segment_into(b"", &mut cursor, &mut out).unwrap_err();
+        assert!(matches!(err, Error::VlqNoValues));
+    }
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -434,9 +434,13 @@ impl PreAllocatedString {
     }
 }
 
-#[test]
-fn test_encode() {
-    let input = r#"{
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_roundtrip() {
+        let input = r#"{
         "version": 3,
         "sources": ["coolstuff.js"],
         "sourceRoot": "x",
@@ -444,16 +448,16 @@ fn test_encode() {
         "mappings": "AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM",
         "x_google_ignoreList": [0]
     }"#;
-    let sm = SourceMap::from_json_string(input).unwrap();
-    let encoded = sm.to_json_string();
-    let sm2 = SourceMap::from_json_string(&encoded).unwrap();
+        let sm = SourceMap::from_json_string(input).unwrap();
+        let encoded = sm.to_json_string();
+        let sm2 = SourceMap::from_json_string(&encoded).unwrap();
 
-    for (tok1, tok2) in sm.get_tokens().zip(sm2.get_tokens()) {
-        assert_eq!(tok1, tok2);
-    }
+        for (tok1, tok2) in sm.get_tokens().zip(sm2.get_tokens()) {
+            assert_eq!(tok1, tok2);
+        }
 
-    // spellchecker:off
-    let input = r#"{
+        // spellchecker:off
+        let input = r#"{
         "version": 3,
         "file": "index.js",
         "names": [
@@ -472,41 +476,41 @@ fn test_encode() {
         ],
         "mappings": ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA,MAAa,MAAM;AAEnBA,OAAK,QAAQ,IAAI;AAEjB,SAASA,OAAK,IAAI,QAAM;AACtB,UAAS,cAAc,GAAG,CAAC,cAAcA;;SAG1B,QAAQ,QAAQ;AAC/B,KAAI,KAAK;AACP,SAAK,QAAQ,IAAI,IAAI;;EAEvB;;;;;;;ACVF,KAAK,QAAQ,QAAQ;AAErB,SAAS,KAAK,IAAI,QAAM;AACtB,UAAS,cAAc,GAAG,CAAC,cAAcC"
     }"#;
-    // spellchecker:on
-    let sm = SourceMap::from_json_string(input).unwrap();
-    let encoded = sm.to_json_string();
-    let sm2 = SourceMap::from_json_string(&encoded).unwrap();
+        // spellchecker:on
+        let sm = SourceMap::from_json_string(input).unwrap();
+        let encoded = sm.to_json_string();
+        let sm2 = SourceMap::from_json_string(&encoded).unwrap();
 
-    for (tok1, tok2) in sm.get_tokens().zip(sm2.get_tokens()) {
-        assert_eq!(tok1, tok2);
+        for (tok1, tok2) in sm.get_tokens().zip(sm2.get_tokens()) {
+            assert_eq!(tok1, tok2);
+        }
     }
-}
 
-#[test]
-fn test_encode_escape_string() {
-    // '\0' should be escaped.
-    let mut sm = SourceMap::new(
-        None,
-        vec!["name_length_greater_than_16_\0".into()],
-        None,
-        vec!["\0".into()],
-        vec![Some("emoji-👀-\0".into())],
-        vec![].into_boxed_slice(),
-        None,
-    );
-    sm.set_x_google_ignore_list(vec![0]);
-    sm.set_debug_id("56431d54-c0a6-451d-8ea2-ba5de5d8ca2e");
-    assert_eq!(
-        sm.to_json_string(),
-        r#"{"version":3,"names":["name_length_greater_than_16_\u0000"],"sources":["\u0000"],"sourcesContent":["emoji-👀-\u0000"],"x_google_ignoreList":[0],"mappings":"","debugId":"56431d54-c0a6-451d-8ea2-ba5de5d8ca2e"}"#
-    );
-}
+    #[test]
+    fn encode_escape_string() {
+        // '\0' should be escaped.
+        let mut sm = SourceMap::new(
+            None,
+            vec!["name_length_greater_than_16_\0".into()],
+            None,
+            vec!["\0".into()],
+            vec![Some("emoji-👀-\0".into())],
+            vec![].into_boxed_slice(),
+            None,
+        );
+        sm.set_x_google_ignore_list(vec![0]);
+        sm.set_debug_id("56431d54-c0a6-451d-8ea2-ba5de5d8ca2e");
+        assert_eq!(
+            sm.to_json_string(),
+            r#"{"version":3,"names":["name_length_greater_than_16_\u0000"],"sources":["\u0000"],"sourcesContent":["emoji-👀-\u0000"],"x_google_ignoreList":[0],"mappings":"","debugId":"56431d54-c0a6-451d-8ea2-ba5de5d8ca2e"}"#
+        );
+    }
 
-#[test]
-fn test_vlq_encode_diff() {
-    // Most import tests here are that with maximum values, `encode_vlq_diff` pushes maximum of 7 bytes.
-    // This invariant is essential to safety of `encode_vlq_diff`.
-    #[rustfmt::skip]
+    #[test]
+    fn vlq_encode_diff() {
+        // Most import tests here are that with maximum values, `encode_vlq_diff` pushes maximum of 7 bytes.
+        // This invariant is essential to safety of `encode_vlq_diff`.
+        #[rustfmt::skip]
     const FIXTURES: &[(u32, u32, &str)] = &[
         (0,           0, "A"),
         (1,           0, "C"),
@@ -542,89 +546,162 @@ fn test_vlq_encode_diff() {
         (0, u32::MAX,    "//////H"), // 7 bytes
     ];
 
-    for (a, b, res) in FIXTURES.iter().copied() {
-        let mut out = String::with_capacity(MAX_VLQ_BYTES);
-        // SAFETY: `out` has 7 bytes spare capacity
-        unsafe { encode_vlq_diff(&mut out, a, b) };
-        assert_eq!(&out, res);
+        for (a, b, res) in FIXTURES.iter().copied() {
+            let mut out = String::with_capacity(MAX_VLQ_BYTES);
+            // SAFETY: `out` has 7 bytes spare capacity
+            unsafe { encode_vlq_diff(&mut out, a, b) };
+            assert_eq!(&out, res);
+        }
     }
-}
 
-#[test]
-fn test_encode_all_sources_content_null() {
-    let sm = SourceMap::new(
-        None,
-        vec![],
-        None,
-        vec!["a.js".into(), "b.js".into()],
-        vec![None, None],
-        vec![].into_boxed_slice(),
-        None,
-    );
-    let json = sm.to_json_string();
-    assert!(
-        !json.contains("sourcesContent"),
-        "sourcesContent should be omitted when all items are None"
-    );
+    #[test]
+    fn encode_all_sources_content_null() {
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec!["a.js".into(), "b.js".into()],
+            vec![None, None],
+            vec![].into_boxed_slice(),
+            None,
+        );
+        let json = sm.to_json_string();
+        assert!(
+            !json.contains("sourcesContent"),
+            "sourcesContent should be omitted when all items are None"
+        );
 
-    let json_map = encode(&sm);
-    assert!(json_map.sources_content.is_none());
+        let json_map = encode(&sm);
+        assert!(json_map.sources_content.is_none());
 
-    let sm = SourceMap::new(
-        None,
-        vec![],
-        None,
-        vec!["a.js".into(), "b.js".into()],
-        vec![Some("content".into()), None],
-        vec![].into_boxed_slice(),
-        None,
-    );
-    let json = sm.to_json_string();
-    assert!(
-        json.contains("sourcesContent"),
-        "sourcesContent should be present when at least one item is Some"
-    );
-    assert!(
-        json.contains(r#""sourcesContent":["content",null]"#),
-        "None source_contents should be encoded as raw null, not quoted \"null\""
-    );
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec!["a.js".into(), "b.js".into()],
+            vec![Some("content".into()), None],
+            vec![].into_boxed_slice(),
+            None,
+        );
+        let json = sm.to_json_string();
+        assert!(
+            json.contains("sourcesContent"),
+            "sourcesContent should be present when at least one item is Some"
+        );
+        assert!(
+            json.contains(r#""sourcesContent":["content",null]"#),
+            "None source_contents should be encoded as raw null, not quoted \"null\""
+        );
 
-    let json_map = encode(&sm);
-    assert!(json_map.sources_content.is_some());
-}
+        let json_map = encode(&sm);
+        assert!(json_map.sources_content.is_some());
+    }
 
-#[test]
-fn test_encode_escape_file_and_source_root() {
-    let sm = SourceMap::new(
-        Some("file\0name.js".into()),
-        vec![],
-        Some("root\0path".into()),
-        vec![],
-        vec![],
-        vec![].into_boxed_slice(),
-        None,
-    );
-    let json = sm.to_json_string();
-    assert!(
-        json.contains(r#""file":"file\u0000name.js""#),
-        "file field should have \\0 escaped: {json}"
-    );
-    assert!(
-        json.contains(r#""sourceRoot":"root\u0000path""#),
-        "sourceRoot field should have \\0 escaped: {json}"
-    );
-    // Verify the output is valid JSON by round-tripping
-    SourceMap::from_json_string(&json).unwrap();
-}
+    #[test]
+    fn encode_escape_file_and_source_root() {
+        let sm = SourceMap::new(
+            Some("file\0name.js".into()),
+            vec![],
+            Some("root\0path".into()),
+            vec![],
+            vec![],
+            vec![].into_boxed_slice(),
+            None,
+        );
+        let json = sm.to_json_string();
+        assert!(
+            json.contains(r#""file":"file\u0000name.js""#),
+            "file field should have \\0 escaped: {json}"
+        );
+        assert!(
+            json.contains(r#""sourceRoot":"root\u0000path""#),
+            "sourceRoot field should have \\0 escaped: {json}"
+        );
+        // Verify the output is valid JSON by round-tripping
+        SourceMap::from_json_string(&json).unwrap();
+    }
 
-#[test]
-fn test_encode_escape_debug_id() {
-    let mut sm = SourceMap::default();
-    // A debug_id containing JSON-special characters must be escaped, otherwise
-    // the output is malformed JSON.
-    sm.set_debug_id("id-with-\"quote\"-and-\\backslash");
-    let json = sm.to_json_string();
-    // Round-trip must succeed (would fail if the quote isn't escaped).
-    let roundtripped = SourceMap::from_json_string(&json).unwrap();
-    assert_eq!(roundtripped.get_debug_id(), Some("id-with-\"quote\"-and-\\backslash"));
+    #[test]
+    fn encode_escape_debug_id() {
+        let mut sm = SourceMap::default();
+        // A debug_id containing JSON-special characters must be escaped, otherwise
+        // the output is malformed JSON.
+        sm.set_debug_id("id-with-\"quote\"-and-\\backslash");
+        let json = sm.to_json_string();
+        // Round-trip must succeed (would fail if the quote isn't escaped).
+        let roundtripped = SourceMap::from_json_string(&json).unwrap();
+        assert_eq!(roundtripped.get_debug_id(), Some("id-with-\"quote\"-and-\\backslash"));
+    }
+
+    #[test]
+    fn encode_reserves_when_estimate_is_tight() {
+        // `to_json` pre-sizes the mappings buffer at ~12 bytes/token. Several
+        // tokens on the *same* generated line with large deltas each need more
+        // than that, forcing the in-loop `reserve` (comma branch) to run.
+        // Odd-indexed tokens carry no name id so the source-without-name
+        // serialization branch is exercised too.
+        let tokens: Vec<Token> = (0..8u32)
+            .map(|i| {
+                let name = if i % 2 == 0 { Some(0) } else { None };
+                Token::new(0, i * 100_000, i * 100_000, i * 100_000, Some(0), name)
+            })
+            .collect();
+        let sm = SourceMap::new(
+            None,
+            vec!["a_reasonably_long_name".into()],
+            None,
+            vec!["a.js".into()],
+            vec![],
+            tokens.into_boxed_slice(),
+            None,
+        );
+
+        // Both encoders must round-trip the same tokens despite the realloc.
+        for encoded in [sm.to_json_string(), encode_to_string(&sm)] {
+            let reparsed = SourceMap::from_json_string(&encoded).unwrap();
+            assert!(sm.get_tokens().eq(reparsed.get_tokens()));
+        }
+        let reparsed = SourceMap::from_json(sm.to_json()).unwrap();
+        assert!(sm.get_tokens().eq(reparsed.get_tokens()));
+    }
+
+    #[test]
+    fn encode_multiline_reserves_on_line_breaks() {
+        // Tokens spread across many generated lines drive the semicolon
+        // (line-break) reserve branch with a tight `to_json` estimate.
+        let tokens: Vec<Token> = (0..8u32)
+            .map(|i| Token::new(i * 3, 50_000, 50_000, 50_000, Some(0), Some(0)))
+            .collect();
+        let sm = SourceMap::new(
+            None,
+            vec!["name".into()],
+            None,
+            vec!["a.js".into()],
+            vec![],
+            tokens.into_boxed_slice(),
+            None,
+        );
+        let reparsed = SourceMap::from_json(sm.to_json()).unwrap();
+        assert!(sm.get_tokens().eq(reparsed.get_tokens()));
+    }
+
+    #[test]
+    fn encode_tokens_without_source() {
+        // Generated-column-only mappings (no source id) skip the source/name
+        // VLQ fields entirely — the `source_id == None` serialization branch.
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![],
+            vec![],
+            vec![Token::new(0, 0, 0, 0, None, None), Token::new(0, 4, 0, 0, None, None)]
+                .into_boxed_slice(),
+            None,
+        );
+        let encoded = sm.to_json_string();
+        let reparsed = SourceMap::from_json_string(&encoded).unwrap();
+        assert!(sm.get_tokens().eq(reparsed.get_tokens()));
+        assert!(reparsed.get_tokens().all(|token| token.get_source_id().is_none()));
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,3 +51,57 @@ impl From<serde_json::Error> for Error {
         Error::BadJson(err)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+
+    use super::*;
+
+    fn bad_json_error() -> serde_json::Error {
+        serde_json::from_str::<u32>("not a number").unwrap_err()
+    }
+
+    #[test]
+    fn display_messages() {
+        assert_eq!(
+            Error::VlqLeftover.to_string(),
+            "VLQ string was malformed and data was left over"
+        );
+        assert_eq!(
+            Error::VlqNoValues.to_string(),
+            "VLQ string was empty and no values could be decoded"
+        );
+        assert_eq!(
+            Error::VlqOverflow.to_string(),
+            "The input encoded a number that didn't fit into i64"
+        );
+        assert!(Error::BadJson(bad_json_error()).to_string().starts_with("JSON parsing error:"));
+        assert_eq!(
+            Error::BadSegmentSize(7).to_string(),
+            "Mapping segment had an unsupported size of 7"
+        );
+        assert_eq!(
+            Error::BadSourceReference(3).to_string(),
+            "Reference to non-existing source at position 3"
+        );
+        assert_eq!(
+            Error::BadNameReference(9).to_string(),
+            "Reference to non-existing name at position 9"
+        );
+    }
+
+    #[test]
+    fn error_source() {
+        // Only `BadJson` wraps an underlying error.
+        assert!(Error::BadJson(bad_json_error()).source().is_some());
+        assert!(Error::VlqLeftover.source().is_none());
+        assert!(Error::BadSegmentSize(1).source().is_none());
+    }
+
+    #[test]
+    fn from_serde_json_error() {
+        let err: Error = bad_json_error().into();
+        assert!(matches!(err, Error::BadJson(_)));
+    }
+}

--- a/src/napi.rs
+++ b/src/napi.rs
@@ -53,3 +53,57 @@ impl From<crate::OwnedSourceMap> for SourceMap {
         Self::from(source_map.into_inner())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SourceMap;
+
+    #[test]
+    fn from_source_map() {
+        let mut inner = crate::SourceMap::new(
+            Some("out.js".into()),
+            vec!["n0".into()],
+            Some("root".into()),
+            vec!["a.js".into()],
+            vec![Some("content".into())],
+            vec![].into_boxed_slice(),
+            None,
+        );
+        inner.set_x_google_ignore_list(vec![0]);
+
+        let napi: SourceMap = inner.into();
+        assert_eq!(napi.version, 3);
+        assert_eq!(napi.file.as_deref(), Some("out.js"));
+        assert_eq!(napi.source_root.as_deref(), Some("root"));
+        assert_eq!(napi.names, vec!["n0".to_string()]);
+        assert_eq!(napi.sources, vec!["a.js".to_string()]);
+        assert_eq!(napi.sources_content, Some(vec!["content".to_string()]));
+        assert_eq!(napi.x_google_ignorelist, Some(vec![0]));
+    }
+
+    #[test]
+    fn null_source_content_becomes_empty_string() {
+        // `sourcesContent` entries that are `null` map to an empty string,
+        // because the napi shape uses `Vec<String>` (no inner `Option`).
+        let inner = crate::SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec!["a.js".into(), "b.js".into()],
+            vec![Some("x".into()), None],
+            vec![].into_boxed_slice(),
+            None,
+        );
+        let napi: SourceMap = inner.into();
+        assert_eq!(napi.sources_content, Some(vec!["x".to_string(), String::new()]));
+    }
+
+    #[test]
+    fn from_owned_source_map() {
+        let owned = crate::OwnedSourceMap::default();
+        let napi: SourceMap = owned.into();
+        assert_eq!(napi.version, 3);
+        assert!(napi.sources.is_empty());
+        assert_eq!(napi.sources_content, None);
+    }
+}

--- a/src/owned_sourcemap.rs
+++ b/src/owned_sourcemap.rs
@@ -246,3 +246,116 @@ impl<'a> SourceMap<'a> {
         OwnedSourceMap::new(self.into_owned())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const JSON: &str = r#"{
+        "version": 3,
+        "file": "out.js",
+        "sourceRoot": "root",
+        "names": ["n0"],
+        "sources": ["a.js"],
+        "sourcesContent": ["AC"],
+        "mappings": "AAAAA",
+        "x_google_ignoreList": [0],
+        "debugId": "dbg"
+    }"#;
+
+    #[test]
+    fn accessors() {
+        let sm = OwnedSourceMap::from_json_string(JSON).unwrap();
+        assert_eq!(sm.get_file(), Some("out.js"));
+        assert_eq!(sm.get_source_root(), Some("root"));
+        assert_eq!(sm.get_x_google_ignore_list(), Some(&[0][..]));
+        assert_eq!(sm.get_debug_id(), Some("dbg"));
+        assert_eq!(sm.get_names().collect::<Vec<_>>(), vec!["n0"]);
+        assert_eq!(sm.get_sources().collect::<Vec<_>>(), vec!["a.js"]);
+        assert_eq!(sm.get_source_contents().collect::<Vec<_>>(), vec![Some("AC")]);
+        assert_eq!(sm.get_name(0), Some("n0"));
+        assert_eq!(sm.get_source(0), Some("a.js"));
+        assert_eq!(sm.get_source_content(0), Some("AC"));
+        assert_eq!(sm.get_source_and_content(0), Some(("a.js", "AC")));
+        assert!(sm.get_token(0).is_some());
+        assert_eq!(sm.get_tokens().count(), 1);
+        assert!(sm.get_source_view_token(0).is_some());
+        assert_eq!(sm.get_source_view_tokens().count(), 1);
+    }
+
+    #[test]
+    fn mutators() {
+        let mut sm = OwnedSourceMap::from_json_string(JSON).unwrap();
+        sm.set_file("new.js");
+        assert_eq!(sm.get_file(), Some("new.js"));
+        sm.set_sources(vec!["b.js"]);
+        assert_eq!(sm.get_source(0), Some("b.js"));
+        sm.set_source_contents(vec![Some("new content")]);
+        assert_eq!(sm.get_source_content(0), Some("new content"));
+        sm.set_x_google_ignore_list(vec![]);
+        assert_eq!(sm.get_x_google_ignore_list(), Some(&[][..]));
+        sm.set_debug_id("newdbg");
+        assert_eq!(sm.get_debug_id(), Some("newdbg"));
+    }
+
+    #[test]
+    fn lookup() {
+        let sm = OwnedSourceMap::from_json_string(JSON).unwrap();
+        let table = sm.generate_lookup_table();
+        assert!(sm.lookup_token(&table, 0, 0).is_some());
+        assert!(sm.lookup_source_view_token(&table, 0, 0).is_some());
+    }
+
+    #[test]
+    fn serialize() {
+        let sm = OwnedSourceMap::from_json_string(JSON).unwrap();
+        assert_eq!(sm.to_json().file.as_deref(), Some("out.js"));
+        assert!(sm.to_json_string().contains("\"file\":\"out.js\""));
+        assert!(sm.to_data_url().starts_with("data:application/json;charset=utf-8;base64,"));
+    }
+
+    #[test]
+    fn from_json_value() {
+        let json = SourceMap::from_json_string(JSON).unwrap().to_json();
+        let sm = OwnedSourceMap::from_json(json).unwrap();
+        assert_eq!(sm.get_file(), Some("out.js"));
+    }
+
+    #[test]
+    fn conversions_and_inner_access() {
+        let inner = SourceMap::from_json_string(JSON).unwrap().into_owned();
+
+        // `new` + borrow accessors.
+        let owned = OwnedSourceMap::new(inner.clone());
+        assert_eq!(owned.as_source_map().get_file(), Some("out.js"));
+
+        // `From<SourceMap>` + mutable inner access.
+        let mut from_sm = OwnedSourceMap::from(inner.clone());
+        from_sm.as_source_map_mut().set_file("z.js");
+        assert_eq!(from_sm.get_file(), Some("z.js"));
+
+        // `Deref` / `DerefMut` to the inner `SourceMap`.
+        let deref: &SourceMap<'static> = &owned;
+        assert_eq!(deref.get_file(), Some("out.js"));
+        let mut owned_mut = owned.clone();
+        let deref_mut: &mut SourceMap<'static> = &mut owned_mut;
+        deref_mut.set_file("deref.js");
+        assert_eq!(owned_mut.get_file(), Some("deref.js"));
+
+        // `into_inner` + `From<OwnedSourceMap>` + `SourceMap::into_owned_sourcemap`.
+        let back: SourceMap<'static> = owned.into_inner();
+        let round: SourceMap<'static> = OwnedSourceMap::from(back.clone()).into();
+        assert_eq!(round.get_file(), Some("out.js"));
+        assert_eq!(back.into_owned_sourcemap().get_file(), Some("out.js"));
+    }
+
+    #[test]
+    fn parts_roundtrip() {
+        let owned = OwnedSourceMap::from_json_string(JSON).unwrap();
+        let parts = owned.into_parts();
+        assert_eq!(parts.file.as_deref(), Some("out.js"));
+        let rebuilt = OwnedSourceMap::from_parts(parts);
+        assert_eq!(rebuilt.get_file(), Some("out.js"));
+        assert_eq!(rebuilt.get_source(0), Some("a.js"));
+    }
+}

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -343,62 +343,184 @@ fn greatest_lower_bound<'a, T, K: Ord, F: Fn(&'a T) -> K>(
     slice.get(idx)
 }
 
-#[test]
-fn test_sourcemap_lookup_token() {
-    let input = r#"{
-        "version": 3,
-        "sources": ["coolstuff.js"],
-        "sourceRoot": "x",
-        "names": ["x","alert"],
-        "mappings": "AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM"
-    }"#;
-    let sm = SourceMap::from_json_string(input).unwrap();
-    let lookup_table = sm.generate_lookup_table();
-    assert_eq!(
-        sm.lookup_source_view_token(&lookup_table, 0, 0).unwrap().to_tuple(),
-        (Some("coolstuff.js"), 0, 0, None)
-    );
-    assert_eq!(
-        sm.lookup_source_view_token(&lookup_table, 0, 3).unwrap().to_tuple(),
-        (Some("coolstuff.js"), 0, 4, Some("x"))
-    );
-    assert_eq!(
-        sm.lookup_source_view_token(&lookup_table, 0, 24).unwrap().to_tuple(),
-        (Some("coolstuff.js"), 2, 8, None)
-    );
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    // Lines continue out to infinity
-    assert_eq!(
-        sm.lookup_source_view_token(&lookup_table, 0, 1000).unwrap().to_tuple(),
-        (Some("coolstuff.js"), 2, 8, None)
-    );
+    #[test]
+    fn lookup_token() {
+        let input = r#"{
+            "version": 3,
+            "sources": ["coolstuff.js"],
+            "sourceRoot": "x",
+            "names": ["x","alert"],
+            "mappings": "AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM"
+        }"#;
+        let sm = SourceMap::from_json_string(input).unwrap();
+        let lookup_table = sm.generate_lookup_table();
+        assert_eq!(
+            sm.lookup_source_view_token(&lookup_table, 0, 0).unwrap().to_tuple(),
+            (Some("coolstuff.js"), 0, 0, None)
+        );
+        assert_eq!(
+            sm.lookup_source_view_token(&lookup_table, 0, 3).unwrap().to_tuple(),
+            (Some("coolstuff.js"), 0, 4, Some("x"))
+        );
+        assert_eq!(
+            sm.lookup_source_view_token(&lookup_table, 0, 24).unwrap().to_tuple(),
+            (Some("coolstuff.js"), 2, 8, None)
+        );
 
-    assert!(sm.lookup_source_view_token(&lookup_table, 1000, 0).is_none());
-}
+        // Lines continue out to infinity
+        assert_eq!(
+            sm.lookup_source_view_token(&lookup_table, 0, 1000).unwrap().to_tuple(),
+            (Some("coolstuff.js"), 2, 8, None)
+        );
 
-#[test]
-fn test_sourcemap_source_view_token() {
-    let sm = SourceMap::new(
-        None,
-        vec![Cow::Borrowed("foo")],
-        None,
-        vec![Cow::Borrowed("foo.js")],
-        vec![],
-        vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
-        None,
-    );
-    let mut source_view_tokens = sm.get_source_view_tokens();
-    assert_eq!(source_view_tokens.next().unwrap().to_tuple(), (Some("foo.js"), 1, 1, Some("foo")));
-}
+        assert!(sm.lookup_source_view_token(&lookup_table, 1000, 0).is_none());
+        // Plain `lookup_token` (not the source-view wrapper) on the same table.
+        assert!(sm.lookup_token(&lookup_table, 0, 0).is_some());
+    }
 
-#[test]
-fn test_mut_sourcemap() {
-    let mut sm = SourceMap::default();
-    sm.set_file("index.js");
-    sm.set_sources(vec!["foo.js"]);
-    sm.set_source_contents(vec![Some("foo")]);
+    #[test]
+    fn source_view_token() {
+        let sm = SourceMap::new(
+            None,
+            vec![Cow::Borrowed("foo")],
+            None,
+            vec![Cow::Borrowed("foo.js")],
+            vec![],
+            vec![Token::new(1, 1, 1, 1, Some(0), Some(0))].into_boxed_slice(),
+            None,
+        );
+        let mut source_view_tokens = sm.get_source_view_tokens();
+        assert_eq!(
+            source_view_tokens.next().unwrap().to_tuple(),
+            (Some("foo.js"), 1, 1, Some("foo"))
+        );
+        // Indexed source-view token accessor, including out-of-range.
+        assert!(sm.get_source_view_token(0).is_some());
+        assert!(sm.get_source_view_token(99).is_none());
+    }
 
-    assert_eq!(sm.get_file(), Some("index.js"));
-    assert_eq!(sm.get_source(0), Some("foo.js"));
-    assert_eq!(sm.get_source_content(0), Some("foo"));
+    #[test]
+    fn mut_sourcemap() {
+        let mut sm = SourceMap::default();
+        sm.set_file("index.js");
+        sm.set_sources(vec!["foo.js"]);
+        sm.set_source_contents(vec![Some("foo")]);
+
+        assert_eq!(sm.get_file(), Some("index.js"));
+        assert_eq!(sm.get_source(0), Some("foo.js"));
+        assert_eq!(sm.get_source_content(0), Some("foo"));
+    }
+
+    #[test]
+    fn from_json_value() {
+        // `SourceMap::from_json` consumes an already-deserialized `JSONSourceMap`,
+        // a different path from the borrowed `from_json_string`.
+        let json = SourceMap::from_json_string(
+            r#"{"version":3,"sources":["a.js"],"names":[],"mappings":"AAAA"}"#,
+        )
+        .unwrap()
+        .to_json();
+        let sm = SourceMap::from_json(json).unwrap();
+        assert_eq!(sm.get_source(0), Some("a.js"));
+    }
+
+    #[test]
+    fn to_data_url() {
+        let sm =
+            SourceMap::from_json_string(r#"{"version":3,"sources":[],"names":[],"mappings":""}"#)
+                .unwrap();
+        assert!(sm.to_data_url().starts_with("data:application/json;charset=utf-8;base64,"));
+    }
+
+    #[test]
+    fn source_and_content() {
+        let sm = SourceMap::from_json_string(
+            r#"{"version":3,"sources":["a.js"],"sourcesContent":["CONTENT"],"names":[],"mappings":"AAAA"}"#,
+        )
+        .unwrap();
+        assert_eq!(sm.get_source_and_content(0), Some(("a.js", "CONTENT")));
+        // Out-of-range source id short-circuits before reading content.
+        assert_eq!(sm.get_source_and_content(99), None);
+
+        // Source present but its content is absent: the second `?` returns `None`.
+        let no_content = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Borrowed("a.js")],
+            vec![],
+            vec![].into_boxed_slice(),
+            None,
+        );
+        assert_eq!(no_content.get_source(0), Some("a.js"));
+        assert_eq!(no_content.get_source_and_content(0), None);
+    }
+
+    #[test]
+    fn parts_roundtrip() {
+        let sm = SourceMap::from_json_string(
+            r#"{"version":3,"file":"f.js","sources":["a.js"],"names":["n"],"mappings":"AAAAA"}"#,
+        )
+        .unwrap();
+        let parts = sm.into_parts();
+        assert_eq!(parts.file.as_deref(), Some("f.js"));
+        // Reassemble via `from_parts` and via the `From<SourceMapParts>` impl.
+        let rebuilt = SourceMap::from_parts(parts);
+        assert_eq!(rebuilt.get_file(), Some("f.js"));
+        let from_parts: SourceMap = rebuilt.into_parts().into();
+        assert_eq!(from_parts.get_source(0), Some("a.js"));
+    }
+
+    #[test]
+    fn empty_lookup_table() {
+        // No tokens => empty table, and lookups return `None`.
+        let sm = SourceMap::default();
+        assert!(sm.generate_lookup_table().is_empty());
+        assert!(sm.lookup_token(&[], 0, 0).is_none());
+    }
+
+    #[test]
+    fn lookup_before_first_token() {
+        // The only token starts at column 5; looking up column 0 falls before
+        // it, exercising the `checked_sub(1)` underflow guard in
+        // `greatest_lower_bound`.
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Borrowed("a.js")],
+            vec![],
+            vec![Token::new(0, 5, 0, 0, Some(0), None)].into_boxed_slice(),
+            None,
+        );
+        let table = sm.generate_lookup_table();
+        assert!(sm.lookup_token(&table, 0, 0).is_none());
+    }
+
+    #[test]
+    fn lookup_with_duplicate_columns() {
+        // Several tokens share the same generated position (line 0, col 7). A
+        // lookup there finds an exact match, then walks back over the equal-key
+        // run in `greatest_lower_bound` and returns the *first* duplicate.
+        let mut tokens = vec![Token::new(0, 0, 9, 9, Some(0), None)];
+        for src_line in 1..=5 {
+            tokens.push(Token::new(0, 7, src_line, 0, Some(0), None));
+        }
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Borrowed("a.js")],
+            vec![],
+            tokens.into_boxed_slice(),
+            None,
+        );
+        let table = sm.generate_lookup_table();
+        // The earliest token at column 7 wins (src_line 1).
+        assert_eq!(sm.lookup_token(&table, 0, 7).unwrap().get_src_line(), 1);
+    }
 }

--- a/src/sourcemap_builder.rs
+++ b/src/sourcemap_builder.rs
@@ -136,43 +136,88 @@ impl<'a> SourceMapBuilder<'a> {
     }
 }
 
-#[test]
-fn test_sourcemap_builder() {
-    let mut builder = SourceMapBuilder::default();
-    builder.set_source_and_content("baz.js", "");
-    builder.add_name("x");
-    builder.set_file("file");
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let sm = builder.into_sourcemap();
-    assert_eq!(sm.get_source(0), Some("baz.js"));
-    assert_eq!(sm.get_name(0), Some("x"));
-    assert_eq!(sm.get_file(), Some("file"));
+    #[test]
+    fn build() {
+        let mut builder = SourceMapBuilder::default();
+        builder.set_source_and_content("baz.js", "");
+        builder.add_name("x");
+        builder.set_file("file");
 
-    let expected = r#"{"version":3,"file":"file","names":["x"],"sources":["baz.js"],"sourcesContent":[""],"mappings":""}"#;
-    assert_eq!(expected, sm.to_json_string());
-}
+        let sm = builder.into_sourcemap();
+        assert_eq!(sm.get_source(0), Some("baz.js"));
+        assert_eq!(sm.get_name(0), Some("x"));
+        assert_eq!(sm.get_file(), Some("file"));
 
-#[test]
-fn test_sourcemap_builder_dedup() {
-    let mut builder = SourceMapBuilder::default();
-    let id_a = builder.add_name("foo");
-    let id_b = builder.add_name("bar");
-    let id_a_again = builder.add_name("foo");
-    let id_b_again = builder.add_name("bar");
-    assert_eq!(id_a, id_a_again);
-    assert_eq!(id_b, id_b_again);
-    assert_ne!(id_a, id_b);
+        let expected = r#"{"version":3,"file":"file","names":["x"],"sources":["baz.js"],"sourcesContent":[""],"mappings":""}"#;
+        assert_eq!(expected, sm.to_json_string());
+    }
 
-    let src_a = builder.add_source_and_content("a.js", "content a");
-    let src_b = builder.add_source_and_content("b.js", "content b");
-    let src_a_again = builder.add_source_and_content("a.js", "different content (ignored)");
-    assert_eq!(src_a, src_a_again);
-    assert_ne!(src_a, src_b);
+    #[test]
+    fn dedup() {
+        let mut builder = SourceMapBuilder::default();
+        let id_a = builder.add_name("foo");
+        let id_b = builder.add_name("bar");
+        let id_a_again = builder.add_name("foo");
+        let id_b_again = builder.add_name("bar");
+        assert_eq!(id_a, id_a_again);
+        assert_eq!(id_b, id_b_again);
+        assert_ne!(id_a, id_b);
 
-    let sm = builder.into_sourcemap();
-    assert_eq!(sm.get_names().collect::<Vec<_>>(), vec!["foo", "bar"]);
-    assert_eq!(sm.get_sources().collect::<Vec<_>>(), vec!["a.js", "b.js"]);
-    // Source content for the first add wins; the second add returns the
-    // existing id without overwriting.
-    assert_eq!(sm.get_source_content(src_a), Some("content a"));
+        let src_a = builder.add_source_and_content("a.js", "content a");
+        let src_b = builder.add_source_and_content("b.js", "content b");
+        let src_a_again = builder.add_source_and_content("a.js", "different content (ignored)");
+        assert_eq!(src_a, src_a_again);
+        assert_ne!(src_a, src_b);
+
+        let sm = builder.into_sourcemap();
+        assert_eq!(sm.get_names().collect::<Vec<_>>(), vec!["foo", "bar"]);
+        assert_eq!(sm.get_sources().collect::<Vec<_>>(), vec!["a.js", "b.js"]);
+        // Source content for the first add wins; the second add returns the
+        // existing id without overwriting.
+        assert_eq!(sm.get_source_content(src_a), Some("content a"));
+    }
+
+    #[test]
+    fn add_token_and_chunks() {
+        let mut builder = SourceMapBuilder::default();
+        let name_id = builder.add_name("n");
+        let source_id = builder.add_source_and_content("s.js", "src");
+        builder.add_token(0, 0, 0, 0, Some(source_id), Some(name_id));
+        builder.add_token(0, 4, 0, 4, Some(source_id), None);
+        builder.set_token_chunks(vec![TokenChunk::new(0, 2, 0, 0, 0, 0, 0, 0)]);
+
+        let sm = builder.into_sourcemap();
+        assert!(sm.token_chunks.is_some());
+        assert_eq!(sm.get_tokens().count(), 2);
+        assert_eq!(sm.get_token(0), Some(Token::new(0, 0, 0, 0, Some(0), Some(0))));
+    }
+
+    #[test]
+    fn into_owned_sourcemap() {
+        let mut builder = SourceMapBuilder::default();
+        builder.set_file("f.js");
+        let name_id = builder.add_name("n");
+        let source_id = builder.add_source_and_content("s.js", "src");
+        builder.add_token(0, 0, 0, 0, Some(source_id), Some(name_id));
+        builder.set_token_chunks(vec![TokenChunk::new(0, 1, 0, 0, 0, 0, 0, 0)]);
+
+        let owned = builder.into_owned_sourcemap();
+        assert_eq!(owned.get_file(), Some("f.js"));
+        assert_eq!(owned.get_name(0), Some("n"));
+        assert_eq!(owned.get_source(0), Some("s.js"));
+        assert_eq!(owned.get_source_content(0), Some("src"));
+        assert_eq!(owned.get_tokens().count(), 1);
+    }
+
+    #[test]
+    fn into_owned_sourcemap_without_chunks() {
+        // No token chunks set: exercises the `None` branch of the chunk shrink.
+        let owned = SourceMapBuilder::default().into_owned_sourcemap();
+        assert_eq!(owned.get_tokens().count(), 0);
+        assert!(owned.as_source_map().token_chunks.is_none());
+    }
 }

--- a/src/sourcemap_visualizer.rs
+++ b/src/sourcemap_visualizer.rs
@@ -158,3 +158,86 @@ impl<'a, 'sm> SourcemapVisualizer<'a, 'sm> {
             .into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::*;
+    use crate::Token;
+
+    #[test]
+    fn get_url() {
+        let sm =
+            SourceMap::from_json_string(r#"{"version":3,"sources":[],"names":[],"mappings":""}"#)
+                .unwrap();
+        let url = SourcemapVisualizer::new("code", &sm).get_url();
+        assert!(url.starts_with("https://evanw.github.io/source-map-visualization/#"));
+    }
+
+    #[test]
+    fn no_source_contents() {
+        // Sources present but no `sourcesContent` at all.
+        let sm = SourceMap::from_json_string(
+            r#"{"version":3,"sources":["a.js"],"names":[],"mappings":"AAAA"}"#,
+        )
+        .unwrap();
+        assert_eq!(SourcemapVisualizer::new("a", &sm).get_text(), "[no source contents]\n");
+    }
+
+    #[test]
+    fn skips_tokens_without_resolvable_source() {
+        // First token has no source id, second points at a source whose content
+        // is `None`; both are skipped, and only the third (valid) token prints.
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Borrowed("a.js"), Cow::Borrowed("b.js")],
+            vec![Some(Cow::Borrowed("hello\n")), None],
+            vec![
+                Token::new(0, 0, 0, 0, None, None),
+                Token::new(0, 1, 0, 0, Some(1), None),
+                Token::new(0, 2, 0, 0, Some(0), None),
+            ]
+            .into_boxed_slice(),
+            None,
+        );
+        let text = SourcemapVisualizer::new("hello\n", &sm).get_text();
+        assert!(text.contains("- a.js"), "{text}");
+        assert!(!text.contains("- b.js"), "{text}");
+    }
+
+    #[test]
+    fn handles_crlf_line_endings() {
+        // CRLF source content exercises the `\r\n` peek branch in the line table.
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Borrowed("a.js")],
+            vec![Some(Cow::Borrowed("aa\r\nbb\r\n"))],
+            vec![Token::new(0, 0, 0, 0, Some(0), None), Token::new(1, 0, 1, 0, Some(0), None)]
+                .into_boxed_slice(),
+            None,
+        );
+        let text = SourcemapVisualizer::new("aa\r\nbb\r\n", &sm).get_text();
+        assert!(text.contains("- a.js"), "{text}");
+    }
+
+    #[test]
+    fn skips_token_with_out_of_range_source() {
+        // A token references a source id past the end of `sources`; the
+        // visualizer skips it via the `get_source` guard rather than panicking.
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Borrowed("a.js")],
+            vec![Some(Cow::Borrowed("aa\n"))],
+            vec![Token::new(0, 0, 0, 0, Some(5), None)].into_boxed_slice(),
+            None,
+        );
+        assert_eq!(SourcemapVisualizer::new("aa\n", &sm).get_text(), "");
+    }
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -180,3 +180,85 @@ impl<'sm, 'data> SourceViewToken<'sm, 'data> {
         (self.get_source(), self.get_src_line(), self.get_src_col(), self.get_name())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::*;
+
+    fn sample_map() -> SourceMap<'static> {
+        SourceMap::new(
+            None,
+            vec![Cow::Borrowed("name0")],
+            None,
+            vec![Cow::Borrowed("src0.js")],
+            vec![Some(Cow::Borrowed("the source content"))],
+            vec![Token::new(2, 3, 4, 5, Some(0), Some(0))].into_boxed_slice(),
+            None,
+        )
+    }
+
+    #[test]
+    fn token_getters() {
+        let token = Token::new(1, 2, 3, 4, Some(5), Some(6));
+        assert_eq!(token.get_dst_line(), 1);
+        assert_eq!(token.get_dst_col(), 2);
+        assert_eq!(token.get_src_line(), 3);
+        assert_eq!(token.get_src_col(), 4);
+        assert_eq!(token.get_source_id(), Some(5));
+        assert_eq!(token.get_name_id(), Some(6));
+
+        let missing = Token::new(0, 0, 0, 0, None, None);
+        assert_eq!(missing.get_source_id(), None);
+        assert_eq!(missing.get_name_id(), None);
+    }
+
+    #[test]
+    fn token_translated() {
+        let token = Token::new(1, 2, 3, 4, Some(5), Some(6));
+        assert_eq!(token.translated(10, 100, 1000), Token::new(11, 2, 3, 4, Some(105), Some(1006)));
+
+        // The missing-id sentinel survives translation rather than wrapping.
+        let missing = Token::new(0, 0, 0, 0, None, None);
+        let shifted = missing.translated(5, 5, 5);
+        assert_eq!(shifted.get_dst_line(), 5);
+        assert_eq!(shifted.get_source_id(), None);
+        assert_eq!(shifted.get_name_id(), None);
+    }
+
+    #[test]
+    fn source_view_token_accessors() {
+        let sm = sample_map();
+        let token = sm.get_source_view_token(0).unwrap();
+        assert_eq!(token.get_dst_line(), 2);
+        assert_eq!(token.get_dst_col(), 3);
+        assert_eq!(token.get_src_line(), 4);
+        assert_eq!(token.get_src_col(), 5);
+        assert_eq!(token.get_source_id(), Some(0));
+        assert_eq!(token.get_name_id(), Some(0));
+        assert_eq!(token.get_name(), Some("name0"));
+        assert_eq!(token.get_source(), Some("src0.js"));
+        assert_eq!(token.get_source_content(), Some("the source content"));
+        assert_eq!(token.get_source_and_content(), Some(("src0.js", "the source content")));
+        assert_eq!(token.to_tuple(), (Some("src0.js"), 4, 5, Some("name0")));
+    }
+
+    #[test]
+    fn source_view_token_without_ids() {
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![],
+            vec![],
+            vec![Token::new(0, 0, 0, 0, None, None)].into_boxed_slice(),
+            None,
+        );
+        let token = sm.get_source_view_token(0).unwrap();
+        assert_eq!(token.get_name(), None);
+        assert_eq!(token.get_source(), None);
+        assert_eq!(token.get_source_content(), None);
+        assert_eq!(token.get_source_and_content(), None);
+    }
+}


### PR DESCRIPTION
## Summary

Cleans up the test suite and expands it so `cargo llvm-cov --all-features` covers every production line and branch.

**Coverage: 84.18% → 99.72% lines, 69.55% → 100% functions.** `--show-missing-lines` reports zero uncovered lines; the residual sub-region gaps are all irreducible artifacts (the `_ => false` arm `matches!` generates in test assertions, and unreachable `.unwrap()`/`writeln!` panic edges on infallible ops).

## Cleanup

- Standardize **all** inline tests into idiomatic `#[cfg(test)] mod tests { use super::*; }` blocks — previously a mix of bare `#[test]` fns and `#[cfg(test)]` helpers floating at module scope.
- Drop the redundant `test_` prefix now that tests live in `tests` modules; consistent naming across all 10 modules.
- Fix `test_concat_sourcemap_builder_deduplicates_tokens`, which actually asserted tokens are *not* deduped → rename to `keeps_distinct_boundary_tokens` and add the missing counterpart `dedups_identical_boundary_token` exercising the real dedup branch.

## Coverage added (28 → 67 unit tests)

- **`error.rs`** (10% → 100%): `Display` + `source()` for every variant
- **`napi.rs`** (0% → 100%): both `From` impls incl. null-content → empty-string
- **`owned_sourcemap.rs`** (15% → 100%): all delegated accessors, `Deref`/`DerefMut`, conversions, parts round-trip
- **`sourcemap_builder.rs`** (74% → 100%): `add_token`, `set_token_chunks`, `into_owned_sourcemap` (both chunk branches)
- **`sourcemap`/`token`/`decode`/`encode`/`visualizer`**: owned `from_json` path + its error `?` branches, `to_data_url`, duplicate-column lookup, lookup-before-first-token, VLQ overflow, source-less/name-less encoding, CRLF handling, out-of-range/contentless source skips, and the defensive `VlqNoValues` branch.

## Production change

One small simplification in `decode_mapping`: `shift` only ever takes multiples of 5, so the `shift == 63` arm of the overflow check was unreachable. Collapsed it and the redundant `shift >= 64` guard into a single `if shift > 62` (identical behavior for all reachable inputs, now covered by a test).

Verified: `cargo test` and `cargo test --all-features` pass (67 unit + 4 integration + 2 doctests), `cargo clippy --all-targets --all-features` clean, `typos` clean, formatted.