### PR TITLE
chore: bump cargo-shear to 1.13.1

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -33,7 +33,7 @@ jobs:
           tools: just,dprint,cargo-shear@1.13.1
           components: rustfmt
 
-      - name: cargo-shear@1.13.1
+      - name: cargo-shear
         id: shear
         shell: bash
         run: |

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -30,14 +30,14 @@ jobs:
         with:
           restore-cache: true
           cache-key: warm
-          tools: just,dprint,cargo-shear@1.3.0
+          tools: just,dprint,cargo-shear@1.13.1
           components: rustfmt
 
-      - name: cargo-shear
+      - name: cargo-shear@1.13.1
         id: shear
         shell: bash
         run: |
-          if ! cargo shear --fix; then
+          if ! cargo shear --fix --check-test-targets; then
             echo "shear=true" >> $GITHUB_OUTPUT
           fi
 

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ _default:
 alias r := ready
 
 init:
-  cargo binstall watchexec-cli typos-cli cargo-shear dprint -y
+  cargo binstall watchexec-cli typos-cli cargo-shear@1.13.1 dprint -y
   # Clone tc39 source map tests for spec compliance testing
   git clone https://github.com/tc39/source-map-tests.git tests/source-map-tests || true
 
@@ -22,6 +22,6 @@ ready:
   just fmt
 
 fmt:
-  -cargo shear --fix # remove all unused dependencies
+  -cargo shear --fix --check-test-targets # remove all unused dependencies
   cargo fmt --all
   dprint fmt


### PR DESCRIPTION
Bumps cargo-shear to 1.13.1 and runs cargo shear with `--check-test-targets`.