### PR TITLE
perf: binary-search lookup_token by dst_col only

### DIFF
--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -196,6 +196,30 @@ pub fn bench(c: &mut Criterion) {
     }
     lookup_group.finish();
 
+    // Exercise the `lookup_token` remapping hot path: with the lookup table already
+    // built, probe every token's generated position. This mirrors how bundlers
+    // collapse a sourcemap chain (one lookup per token, per chain link). Throughput
+    // is measured in lookups (elements), not bytes.
+    let mut token_lookup_group = c.benchmark_group("lookup_token");
+    for (name, _bytes, sourcemap) in &parsed_fixtures {
+        let table = sourcemap.generate_lookup_table();
+        let keys: Vec<(u32, u32)> =
+            sourcemap.get_tokens().map(|t| (t.get_dst_line(), t.get_dst_col())).collect();
+        token_lookup_group.throughput(Throughput::Elements(keys.len() as u64));
+        token_lookup_group.bench_with_input(
+            BenchmarkId::from_parameter(name),
+            &(table, keys),
+            |b, (table, keys)| {
+                b.iter(|| {
+                    for &(line, col) in keys {
+                        black_box(sourcemap.lookup_token(table, line, col));
+                    }
+                });
+            },
+        );
+    }
+    token_lookup_group.finish();
+
     c.bench_function("builder/SourceMapBuilder::build_single", |b| {
         b.iter(|| {
             let mut builder = SourceMapBuilder::default();

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -262,6 +262,7 @@ impl<'a> SourceMap<'a> {
     }
 
     /// Lookup a token by line and column, it will used at remapping.
+    #[inline]
     pub fn lookup_token(
         &self,
         lookup_table: &[LineLookupTable],
@@ -272,9 +273,11 @@ impl<'a> SourceMap<'a> {
         if line >= lookup_table.len() as u32 {
             return None;
         }
-        let token = greatest_lower_bound(lookup_table[line as usize], &(line, col), |token| {
-            (token.dst_line, token.dst_col)
-        })?;
+        // Every token in `lookup_table[line]` has `dst_line == line` (see `generate_lookup_table`),
+        // so the line component of the key is constant across the slice. Binary searching on
+        // `dst_col` alone avoids building and lexicographically comparing a `(dst_line, dst_col)`
+        // tuple on every probe — measurably faster on this remapping hot path.
+        let token = greatest_lower_bound(lookup_table[line as usize], &col, |token| token.dst_col)?;
         Some(*token)
     }
 


### PR DESCRIPTION
## What

`SourceMap::lookup_token` binary-searches a line's token slice for the
greatest token `<= (line, col)`. Every token in `lookup_table[line]` is built
to have `dst_line == line` (see `generate_lookup_table`), so searching the full
`(dst_line, dst_col)` tuple compares a component that is constant across the
slice on every probe. Searching `dst_col` alone is equivalent and avoids
building/comparing a tuple per step.

This is the per-token remapping hot path: bundlers call it once per token, per
chain link, when collapsing a sourcemap chain.

This PR:
- searches `dst_col` only in `lookup_token`;
- marks `lookup_token` `#[inline]` so it inlines into cross-crate callers;
- adds a `lookup_token` benchmark group — the existing `lookup_table` group only
  measured `generate_lookup_table` (table construction), not the lookups.

## Results

Microbench (`benches/simple.rs`, criterion, before → after):

| fixture | before | after | change |
| --- | --- | --- | --- |
| `lookup_token/real_small` | 21.67 ns | 14.00 ns | −35% |
| `lookup_token/real_medium` | 70.25 ns | 36.47 ns | −48% |
| `lookup_token/real_large` | 1.555 µs | 0.723 µs | −54% |
| `lookup_token/real_xlarge` | 54.06 µs | 25.68 µs | −52% |

End-to-end in rolldown (via a local `[patch.crates-io]`), `cargo bench -p bench`:

| bench | before | after | change |
| --- | --- | --- | --- |
| `sourcemap/collapse_codegen_chain` | 4.267 ms | 2.263 ms | **−47%** (p < 0.05) |
| `sourcemap/join_with_sourcemap` (control) | 571 µs | 582 µs | no change (p = 0.52) |
| `sourcemap/join_no_sourcemap` (control) | 43.5 µs | 43.4 µs | no change (p = 0.76) |

The two controls are untouched by this change, confirming the delta is isolated
to the lookup path.

## Correctness

`dst_line` is invariant within `lookup_table[line]`, so the tuple and
`dst_col`-only searches are equivalent (including the equal-key run handled by
`greatest_lower_bound`). All existing tests pass (`cargo test`), including
`lookup_token`, `lookup_with_duplicate_columns`, and `lookup_before_first_token`;
`cargo clippy --all-targets --all-features` is clean.

---

_Disclosure: this change was developed with AI assistance (Claude), and reviewed,
benchmarked, and verified by the author before submission._
