### PR TITLE
feat: add lookup_token_approx for lossless sourcemap composition

### DIFF
--- a/src/owned_sourcemap.rs
+++ b/src/owned_sourcemap.rs
@@ -195,6 +195,24 @@ impl OwnedSourceMap {
         self.inner.lookup_source_view_token(lookup_table, line, col)
     }
 
+    pub fn lookup_token_approx(
+        &self,
+        lookup_table: &[&[Token]],
+        line: u32,
+        col: u32,
+    ) -> Option<Token> {
+        self.inner.lookup_token_approx(lookup_table, line, col)
+    }
+
+    pub fn lookup_source_view_token_approx(
+        &self,
+        lookup_table: &[&[Token]],
+        line: u32,
+        col: u32,
+    ) -> Option<SourceViewToken<'_, 'static>> {
+        self.inner.lookup_source_view_token_approx(lookup_table, line, col)
+    }
+
     // ---------- structural ----------
 
     /// Take the inner parts; same as `SourceMap::into_parts`.

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -290,6 +290,46 @@ impl<'a> SourceMap<'a> {
     ) -> Option<SourceViewToken<'_, 'a>> {
         self.lookup_token(lookup_table, line, col).map(|token| SourceViewToken::new(token, self))
     }
+
+    /// Like [`lookup_token`](Self::lookup_token), but clamps to the line's first token when `col`
+    /// falls *before* it, instead of returning `None`.
+    ///
+    /// `lookup_token` returns the greatest token with destination `<= (line, col)`, so a query
+    /// before a line's first token yields `None`. That is correct for a plain position lookup, but
+    /// it drops mappings when *composing* sourcemaps — e.g. remapping a token whose column lands
+    /// before the previous map's first token on that line (a line indented past column 0). Clamping
+    /// to the nearest token keeps the mapping, matching Rollup's `collapseSourcemaps` `traceSegment`.
+    /// An empty line (or a line past the end of the table) still returns `None`.
+    pub fn lookup_token_approx(
+        &self,
+        lookup_table: &[LineLookupTable],
+        line: u32,
+        col: u32,
+    ) -> Option<Token> {
+        if line >= lookup_table.len() as u32 {
+            return None;
+        }
+        let line_tokens = lookup_table[line as usize];
+        match greatest_lower_bound(line_tokens, &(line, col), |token| {
+            (token.dst_line, token.dst_col)
+        }) {
+            Some(token) => Some(*token),
+            // `greatest_lower_bound` only yields `None` when `col` precedes the first token on the
+            // line, so clamp to that first token. An empty line has no first token and stays `None`.
+            None => line_tokens.first().copied(),
+        }
+    }
+
+    /// The [`SourceViewToken`] counterpart of [`lookup_token_approx`](Self::lookup_token_approx).
+    pub fn lookup_source_view_token_approx(
+        &self,
+        lookup_table: &[LineLookupTable],
+        line: u32,
+        col: u32,
+    ) -> Option<SourceViewToken<'_, 'a>> {
+        self.lookup_token_approx(lookup_table, line, col)
+            .map(|token| SourceViewToken::new(token, self))
+    }
 }
 
 /// Owned destructured parts of a [`SourceMap`].
@@ -525,5 +565,121 @@ mod tests {
         let table = sm.generate_lookup_table();
         // The earliest token at column 7 wins (src_line 1).
         assert_eq!(sm.lookup_token(&table, 0, 7).unwrap().get_src_line(), 1);
+    }
+
+    #[test]
+    fn lookup_token_approx_clamps_to_first_token_before_line() {
+        // Same setup as `lookup_before_first_token`: the only token starts at column 5, and the
+        // query at column 0 falls before it. `lookup_token` drops it (`None`); the approximating
+        // variant clamps to that first token instead, keeping the mapping alive.
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Borrowed("a.js")],
+            vec![],
+            vec![Token::new(0, 5, 3, 7, Some(0), None)].into_boxed_slice(),
+            None,
+        );
+        let table = sm.generate_lookup_table();
+
+        assert!(sm.lookup_token(&table, 0, 0).is_none());
+
+        let approx = sm.lookup_token_approx(&table, 0, 0).unwrap();
+        assert_eq!((approx.get_dst_line(), approx.get_dst_col()), (0, 5));
+        assert_eq!((approx.get_src_line(), approx.get_src_col()), (3, 7));
+    }
+
+    #[test]
+    fn lookup_token_approx_indented_line_keeps_mapping() {
+        // Models the composition bug (rolldown#10070): the line's first token sits *after* the
+        // indentation (column 1, the `\t`-prefixed statement). A query at column 0 must not drop
+        // the line — it should clamp to that first real token so the statement stays mapped.
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Borrowed("a.js")],
+            vec![],
+            vec![
+                Token::new(0, 1, 1, 2, Some(0), None), // `globalThis` after a leading tab
+                Token::new(0, 12, 1, 13, Some(0), None), // `side`
+            ]
+            .into_boxed_slice(),
+            None,
+        );
+        let table = sm.generate_lookup_table();
+
+        // Plain lookup drops the column-0 query (nothing at col <= 0 on this line).
+        assert!(sm.lookup_token(&table, 0, 0).is_none());
+        // Approx clamps to the first token on the line.
+        assert_eq!(sm.lookup_token_approx(&table, 0, 0).unwrap().get_src_col(), 2);
+        // A query at/after a token still resolves to the greatest lower bound, exactly like
+        // `lookup_token` — the approximation only kicks in for the before-first-token case.
+        assert_eq!(sm.lookup_token(&table, 0, 12).unwrap().get_src_col(), 13);
+        assert_eq!(sm.lookup_token_approx(&table, 0, 12).unwrap().get_src_col(), 13);
+        assert_eq!(sm.lookup_token_approx(&table, 0, 20).unwrap().get_src_col(), 13);
+    }
+
+    #[test]
+    fn lookup_token_approx_empty_and_out_of_range_are_none() {
+        // No tokens on the line, or a line past the end of the table, has nothing to clamp to.
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Borrowed("a.js")],
+            vec![],
+            vec![Token::new(1, 0, 0, 0, Some(0), None)].into_boxed_slice(),
+            None,
+        );
+        let table = sm.generate_lookup_table();
+
+        // Line 0 exists in the table but has no tokens (the only token is on line 1).
+        assert!(sm.lookup_token_approx(&table, 0, 0).is_none());
+        // Line 5 is past the end of the table.
+        assert!(sm.lookup_token_approx(&table, 5, 0).is_none());
+        // Empty table.
+        assert!(sm.lookup_token_approx(&[], 0, 0).is_none());
+    }
+
+    #[test]
+    fn lookup_token_approx_does_not_clamp_when_a_column_0_token_exists() {
+        // The clamp only kicks in on a true underflow. When the line already has a token at
+        // column 0, a column-0 query is an exact match and must return it (not "approximate").
+        let sm = SourceMap::new(
+            None,
+            vec![],
+            None,
+            vec![Cow::Borrowed("a.js")],
+            vec![],
+            vec![Token::new(0, 0, 5, 5, Some(0), None), Token::new(0, 10, 6, 6, Some(0), None)]
+                .into_boxed_slice(),
+            None,
+        );
+        let table = sm.generate_lookup_table();
+        let token = sm.lookup_token_approx(&table, 0, 0).unwrap();
+        assert_eq!((token.get_src_line(), token.get_src_col()), (5, 5));
+    }
+
+    #[test]
+    fn lookup_source_view_token_approx_resolves_source_name_and_content() {
+        // The source-view wrapper must carry the clamped token's source/name/content through.
+        let sm = SourceMap::new(
+            None,
+            vec![Cow::Borrowed("myName")],
+            None,
+            vec![Cow::Borrowed("a.js")],
+            vec![Some(Cow::Borrowed("source code"))],
+            vec![Token::new(0, 5, 1, 2, Some(0), Some(0))].into_boxed_slice(),
+            None,
+        );
+        let table = sm.generate_lookup_table();
+        // Column 0 is before the only token (col 5); the approximating wrapper clamps to it.
+        let sv = sm.lookup_source_view_token_approx(&table, 0, 0).unwrap();
+        assert_eq!(sv.get_source(), Some("a.js"));
+        assert_eq!(sv.get_source_content(), Some("source code"));
+        assert_eq!(sv.get_name(), Some("myName"));
+        assert_eq!((sv.get_src_line(), sv.get_src_col()), (1, 2));
     }
 }

--- a/src/sourcemap.rs
+++ b/src/sourcemap.rs
@@ -310,9 +310,8 @@ impl<'a> SourceMap<'a> {
             return None;
         }
         let line_tokens = lookup_table[line as usize];
-        match greatest_lower_bound(line_tokens, &(line, col), |token| {
-            (token.dst_line, token.dst_col)
-        }) {
+        // Search by `dst_col` alone for the same reason as `lookup_token`.
+        match greatest_lower_bound(line_tokens, &col, |token| token.dst_col) {
             Some(token) => Some(*token),
             // `greatest_lower_bound` only yields `None` when `col` precedes the first token on the
             // line, so clamp to that first token. An empty line has no first token and stays `None`.
@@ -565,121 +564,5 @@ mod tests {
         let table = sm.generate_lookup_table();
         // The earliest token at column 7 wins (src_line 1).
         assert_eq!(sm.lookup_token(&table, 0, 7).unwrap().get_src_line(), 1);
-    }
-
-    #[test]
-    fn lookup_token_approx_clamps_to_first_token_before_line() {
-        // Same setup as `lookup_before_first_token`: the only token starts at column 5, and the
-        // query at column 0 falls before it. `lookup_token` drops it (`None`); the approximating
-        // variant clamps to that first token instead, keeping the mapping alive.
-        let sm = SourceMap::new(
-            None,
-            vec![],
-            None,
-            vec![Cow::Borrowed("a.js")],
-            vec![],
-            vec![Token::new(0, 5, 3, 7, Some(0), None)].into_boxed_slice(),
-            None,
-        );
-        let table = sm.generate_lookup_table();
-
-        assert!(sm.lookup_token(&table, 0, 0).is_none());
-
-        let approx = sm.lookup_token_approx(&table, 0, 0).unwrap();
-        assert_eq!((approx.get_dst_line(), approx.get_dst_col()), (0, 5));
-        assert_eq!((approx.get_src_line(), approx.get_src_col()), (3, 7));
-    }
-
-    #[test]
-    fn lookup_token_approx_indented_line_keeps_mapping() {
-        // Models the composition bug (rolldown#10070): the line's first token sits *after* the
-        // indentation (column 1, the `\t`-prefixed statement). A query at column 0 must not drop
-        // the line — it should clamp to that first real token so the statement stays mapped.
-        let sm = SourceMap::new(
-            None,
-            vec![],
-            None,
-            vec![Cow::Borrowed("a.js")],
-            vec![],
-            vec![
-                Token::new(0, 1, 1, 2, Some(0), None), // `globalThis` after a leading tab
-                Token::new(0, 12, 1, 13, Some(0), None), // `side`
-            ]
-            .into_boxed_slice(),
-            None,
-        );
-        let table = sm.generate_lookup_table();
-
-        // Plain lookup drops the column-0 query (nothing at col <= 0 on this line).
-        assert!(sm.lookup_token(&table, 0, 0).is_none());
-        // Approx clamps to the first token on the line.
-        assert_eq!(sm.lookup_token_approx(&table, 0, 0).unwrap().get_src_col(), 2);
-        // A query at/after a token still resolves to the greatest lower bound, exactly like
-        // `lookup_token` — the approximation only kicks in for the before-first-token case.
-        assert_eq!(sm.lookup_token(&table, 0, 12).unwrap().get_src_col(), 13);
-        assert_eq!(sm.lookup_token_approx(&table, 0, 12).unwrap().get_src_col(), 13);
-        assert_eq!(sm.lookup_token_approx(&table, 0, 20).unwrap().get_src_col(), 13);
-    }
-
-    #[test]
-    fn lookup_token_approx_empty_and_out_of_range_are_none() {
-        // No tokens on the line, or a line past the end of the table, has nothing to clamp to.
-        let sm = SourceMap::new(
-            None,
-            vec![],
-            None,
-            vec![Cow::Borrowed("a.js")],
-            vec![],
-            vec![Token::new(1, 0, 0, 0, Some(0), None)].into_boxed_slice(),
-            None,
-        );
-        let table = sm.generate_lookup_table();
-
-        // Line 0 exists in the table but has no tokens (the only token is on line 1).
-        assert!(sm.lookup_token_approx(&table, 0, 0).is_none());
-        // Line 5 is past the end of the table.
-        assert!(sm.lookup_token_approx(&table, 5, 0).is_none());
-        // Empty table.
-        assert!(sm.lookup_token_approx(&[], 0, 0).is_none());
-    }
-
-    #[test]
-    fn lookup_token_approx_does_not_clamp_when_a_column_0_token_exists() {
-        // The clamp only kicks in on a true underflow. When the line already has a token at
-        // column 0, a column-0 query is an exact match and must return it (not "approximate").
-        let sm = SourceMap::new(
-            None,
-            vec![],
-            None,
-            vec![Cow::Borrowed("a.js")],
-            vec![],
-            vec![Token::new(0, 0, 5, 5, Some(0), None), Token::new(0, 10, 6, 6, Some(0), None)]
-                .into_boxed_slice(),
-            None,
-        );
-        let table = sm.generate_lookup_table();
-        let token = sm.lookup_token_approx(&table, 0, 0).unwrap();
-        assert_eq!((token.get_src_line(), token.get_src_col()), (5, 5));
-    }
-
-    #[test]
-    fn lookup_source_view_token_approx_resolves_source_name_and_content() {
-        // The source-view wrapper must carry the clamped token's source/name/content through.
-        let sm = SourceMap::new(
-            None,
-            vec![Cow::Borrowed("myName")],
-            None,
-            vec![Cow::Borrowed("a.js")],
-            vec![Some(Cow::Borrowed("source code"))],
-            vec![Token::new(0, 5, 1, 2, Some(0), Some(0))].into_boxed_slice(),
-            None,
-        );
-        let table = sm.generate_lookup_table();
-        // Column 0 is before the only token (col 5); the approximating wrapper clamps to it.
-        let sv = sm.lookup_source_view_token_approx(&table, 0, 0).unwrap();
-        assert_eq!(sv.get_source(), Some("a.js"));
-        assert_eq!(sv.get_source_content(), Some("source code"));
-        assert_eq!(sv.get_name(), Some("myName"));
-        assert_eq!((sv.get_src_line(), sv.get_src_col()), (1, 2));
     }
 }

--- a/tests/lookup_token_approx.rs
+++ b/tests/lookup_token_approx.rs
@@ -1,0 +1,72 @@
+use oxc_sourcemap::{OwnedSourceMap, SourceMapBuilder};
+
+/// End-to-end model of the composition scenario `lookup_token_approx` exists
+/// for (rolldown/rolldown#10070): an indented line whose mapping survives
+/// collapsing a two-map chain only because the lookup clamps instead of
+/// returning `None`.
+#[test]
+fn compose_sourcemaps_with_approx_lookup_keeps_indented_lines() {
+    // Stage 1 — codegen wraps the source in a function, indenting it one tab:
+    //
+    //   a.js (original):        intermediate.js (generated):
+    //   globalThis.side = 1;    function wrap() {
+    //                           \tglobalThis.side = 1;
+    //                           }
+    //
+    // Codegen anchors at real tokens, so the indented line's first mapping
+    // sits *after* the tab, at column 1. Nothing maps column 0.
+    let mut codegen = SourceMapBuilder::default();
+    let src = codegen.add_source_and_content("a.js", "globalThis.side = 1;");
+    let name = codegen.add_name("side");
+    codegen.add_token(1, 1, 0, 0, Some(src), None); // `globalThis`, after the tab
+    codegen.add_token(1, 12, 0, 11, Some(src), Some(name)); // `side`
+    let codegen_map = codegen.into_sourcemap();
+
+    // Stage 2 — the bundler concatenates chunks, landing the wrapper at line 3
+    // of the bundle, and samples the moved line at its *start* (column 0).
+    let mut bundler = SourceMapBuilder::default();
+    let chunk = bundler
+        .add_source_and_content("intermediate.js", "function wrap() {\n\tglobalThis.side = 1;\n}");
+    bundler.add_token(3, 0, 1, 0, Some(chunk), None); // bundle (3,0) -> intermediate (1,0)
+    let bundler_map = bundler.into_sourcemap();
+
+    // Stage 3 — compose the chain the way a bundler collapses it: resolve each
+    // bundle token's intermediate position through the codegen map.
+    let table = codegen_map.generate_lookup_table();
+    let mut composed = SourceMapBuilder::default();
+    for token in bundler_map.get_tokens() {
+        let (line, col) = (token.get_src_line(), token.get_src_col());
+
+        // The strict lookup lands before the line's first token (column 0 < 1)
+        // and returns `None` — composing with it would silently drop the whole
+        // statement from the final map.
+        assert!(codegen_map.lookup_token(&table, line, col).is_none());
+
+        // The approximating lookup clamps to the line's first token instead.
+        let origin = codegen_map
+            .lookup_source_view_token_approx(&table, line, col)
+            .expect("approx lookup must resolve the indented line");
+        let src_id = composed.add_source_and_content(
+            origin.get_source().unwrap(),
+            origin.get_source_content().unwrap(),
+        );
+        composed.add_token(
+            token.get_dst_line(),
+            token.get_dst_col(),
+            origin.get_src_line(),
+            origin.get_src_col(),
+            Some(src_id),
+            None,
+        );
+    }
+
+    // Stage 4 — the composed map round-trips through JSON (encode + decode)
+    // and still resolves the bundle position back to the original source.
+    let json = composed.into_sourcemap().to_json_string();
+    let composed = OwnedSourceMap::from_json_string(&json).unwrap();
+    let table = composed.generate_lookup_table();
+    let origin = composed.lookup_source_view_token_approx(&table, 3, 0).unwrap();
+    assert_eq!(origin.get_source(), Some("a.js"));
+    assert_eq!(origin.get_source_content(), Some("globalThis.side = 1;"));
+    assert_eq!((origin.get_src_line(), origin.get_src_col()), (0, 0));
+}


### PR DESCRIPTION
## What
Adds `SourceMap::lookup_token_approx` (+ `lookup_source_view_token_approx`): like `lookup_token`, but when the queried column is *before* the first token on a line, it clamps to that first token instead of returning `None`. `lookup_token` is unchanged.

## Why — with vs. without
`lookup_token` returns the greatest token `<= (line, col)`, so a query before a line's first token returns `None`. Correct for a plain position lookup — but it silently drops mappings when **composing** two sourcemaps, and it only surfaces on indented lines.

```
Indented generated line (→ = leading tab):

    →globalThis.side = 1;
    ↑↑
    ↑└ col 1 — codegen's first token ("globalThis")
    └ col 0 — the tab, no token here

A composer remaps the line by querying column 0:

    lookup_token(line, 0)         →  None           ❌  the whole line drops out of the map
    lookup_token_approx(line, 0)  →  token @ col 1  ✅  the line stays mapped
```

Downstream, this is exactly what bit rolldown ([rolldown/rolldown#10070](https://github.com/rolldown/rolldown/issues/10070)): every indented statement that went through map composition lost its mapping, so a debugger could no longer jump from it back to source.

## Prior art — Rollup's `collapseSourcemaps` does exactly this
Rollup's map composer approximates in this same situation instead of dropping the segment — [`src/utils/collapseSourcemaps.ts` L128-L136](https://github.com/rollup/rollup/blob/ff0a94b908e92745136bbd34ddebf7e1bbae1f59/src/utils/collapseSourcemaps.ts#L128-L136):

```ts
// If a sourcemap does not have sufficient resolution to contain a
// necessary mapping, e.g. because it only contains line information or
// the column is not precise (e.g. the sourcemap is generated by esbuild, segment[0] may be shorter than the location of the first letter),
// we approximate by finding the closest segment whose segment[0] is less than the given column
if (segment[0] !== column && searchStart === searchEnd) {
    const approximatedSegmentIndex =
        segments[searchStart][0] > column ? Math.max(0, searchStart - 1) : searchStart;
    segment = segments[approximatedSegmentIndex];
}
```

When the column precedes the line's first segment (`searchStart === 0` and `segments[0][0] > column`), `Math.max(0, searchStart - 1)` clamps to index `0` — the line's first segment. `lookup_token_approx` returns that same first token; for in-range columns it matches `lookup_token` (Rollup's exact-hit path). An empty/out-of-range line returns `None` in both.

## Notes
- Additive only; `lookup_token`'s "`None` before the first token" contract (and its test) is untouched.
- Both `lookup_token` and this method assume tokens are sorted by `(dst_line, dst_col)` — an existing invariant from `generate_lookup_table`; the approx variant adds no new assumption.
- Empty line / line past the table still returns `None` (nothing to clamp to).

## Tests
A single end-to-end test, `tests/lookup_token_approx.rs::compose_sourcemaps_with_approx_lookup_keeps_indented_lines`, models the whole #10070 pipeline: codegen indents a line (first anchor at column 1), the bundler samples the moved line at column 0, and collapsing the chain resolves the bundle token through the codegen map — asserting the strict lookup drops the mapping while the approximating lookup keeps it. The composed map then round-trips through JSON and resolves the bundle position back to the original source via `OwnedSourceMap` (covering the delegation too).

*(Maintainer edit: rebased on main, replaced the original unit tests with the e2e test above, and aligned the new method's binary search with #385's `dst_col`-only key.)*
