### PR TITLE
chore: bump MSRV to 1.95.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 publish = true
 readme = "README.md"
 repository = "https://github.com/oxc-project/oxc-sourcemap"
-rust-version = "1.88.0"
+rust-version = "1.95.0"
 description = "Basic sourcemap handling for Rust"
 
 # <https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html>

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -293,12 +293,8 @@ unsafe fn encode_vlq_diff(out: &mut String, a: u32, b: u32) {
 #[repr(align(64))]
 struct Aligned64([u8; 64]);
 
-static B64_CHARS: Aligned64 = Aligned64([
-    b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I', b'J', b'K', b'L', b'M', b'N', b'O', b'P',
-    b'Q', b'R', b'S', b'T', b'U', b'V', b'W', b'X', b'Y', b'Z', b'a', b'b', b'c', b'd', b'e', b'f',
-    b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o', b'p', b'q', b'r', b's', b't', b'u', b'v',
-    b'w', b'x', b'y', b'z', b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'+', b'/',
-]);
+static B64_CHARS: Aligned64 =
+    Aligned64(*b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
 
 /// Encode number as VLQ and push encoding into `out`.
 /// Will push between 1 byte (num = 0) and 7 bytes (num = -u32::MAX).


### PR DESCRIPTION
Raise `rust-version` from 1.88.0 to 1.95.0.

Stacked on #408 — merge that first (GitHub will retarget this PR to `main`). Follow-up PRs adopt APIs stabilized in the 1.89–1.95 range.