### PR TITLE
perf: add decode mapping fast path for 4 / 5 segments

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -227,6 +227,75 @@ fn decode_mapping(mapping: &str, names_len: usize, sources_len: usize) -> Result
     Ok(tokens)
 }
 
+/// Fast path for the dominant sourcemap segment shapes: a 4- or 5-field
+/// segment whose VLQ values are all single-byte (no continuation bit),
+/// terminated by `,` / `;` / end-of-input. Both arities are handled because
+/// real bundler output splits roughly 60% 4-field / 25% 5-field (named)
+/// segments; covering only one shape would send the other through the
+/// general parser.
+///
+/// Fills `nums` and returns the field count (the caller advances `cursor`
+/// by the same amount). Returns `None` without consuming anything when the
+/// shape doesn't match, so the general parser can handle multi-byte VLQs,
+/// other arities, and diagnostics.
+///
+/// Byte 4 is probed lazily, after the 4-lane decode, because its meaning is
+/// what distinguishes the two arities: in a 4-field segment it is the
+/// terminator (or absent at end of input), in a 5-field segment it is the
+/// name field. It cannot join the packed lane test for the same reason, and
+/// decoding all 5 lanes eagerly and branching afterwards benchmarked slightly
+/// slower — the branch predictor already speculates into the 5th-field
+/// handling when needed, so eager decoding only adds wasted work per
+/// 4-field segment.
+#[inline(always)]
+fn try_fast_4_or_5_segment(mapping: &[u8], cursor: usize, nums: &mut [i64; 5]) -> Option<usize> {
+    let rest = &mapping[cursor..];
+    if rest.len() < 4 {
+        return None;
+    }
+
+    let v = [
+        B64_DECODE.0[rest[0] as usize] as u8,
+        B64_DECODE.0[rest[1] as usize] as u8,
+        B64_DECODE.0[rest[2] as usize] as u8,
+        B64_DECODE.0[rest[3] as usize] as u8,
+    ];
+    // A table entry with any of the top three bits set (`& 0xE0`) is either a
+    // delimiter (`-1` → `0xFF`) or has the VLQ continuation bit (32..=63)
+    if (v[0] | v[1] | v[2] | v[3]) & 0xE0 != 0 {
+        return None;
+    }
+
+    for i in 0..4 {
+        nums[i] = decode_sign(i64::from(v[i]));
+    }
+
+    let Some(&b4) = rest.get(4) else { return Some(4) };
+    let v4 = B64_DECODE.0[b4 as usize] as u8;
+    if is_delimiter(v4) {
+        return Some(4);
+    }
+
+    // the byte must be a single-byte 5th field with the segment ending right
+    // after it, else fall back (6+ fields, or a multi-byte VLQ anywhere in
+    // the segment).
+    if v4 & 0xE0 != 0
+        || rest.get(5).is_some_and(|&b5| !is_delimiter(B64_DECODE.0[b5 as usize] as u8))
+    {
+        return None;
+    }
+    nums[4] = decode_sign(i64::from(v4));
+    Some(5)
+}
+
+/// Whether a [`B64_DECODE`] entry marks a segment (`,`) or line (`;`)
+/// delimiter.
+#[inline(always)]
+fn is_delimiter(entry: u8) -> bool {
+    // delimiters are the table's only negative entries
+    entry & 0x80 != 0
+}
+
 // Align B64 lookup table on 64-byte boundary for better cache performance
 #[repr(align(64))]
 struct Aligned64([i8; 256]);
@@ -296,6 +365,14 @@ fn estimate_token_capacity(mapping: &[u8]) -> usize {
 /// contains more than 5 fields, we keep parsing and counting so the caller can
 /// reject it with `BadSegmentSize` carrying the true field count.
 fn parse_vlq_segment_into(mapping: &[u8], cursor: &mut usize, rv: &mut [i64; 5]) -> Result<usize> {
+    // The dominant segment shape in real bundler output (~95%) is 4 or 5
+    // single-byte VLQ values; decode it branch-light, leaving multi-byte
+    // VLQs, other arities, and diagnostics to the general loop below.
+    if let Some(seg_len) = try_fast_4_or_5_segment(mapping, *cursor, rv) {
+        *cursor += seg_len;
+        return Ok(seg_len);
+    }
+
     let mut rv_len = 0usize;
     while let Some(value) = next_vlq(mapping, cursor)? {
         if rv_len < rv.len() {


### PR DESCRIPTION
This PR adds a fast path for decoding mappings with 4 / 5 segments.

I also tested using SIMD / SWAR for the complete decoding but I wasn't able to achieve a better perf than this one.

I generated this code with AI and refactored the code.

```
     Running benches/simple.rs (target/release/deps/simple-08930143607fab17)
Benchmarking parse/real_large
Benchmarking parse/real_large: Warming up for 1.0000 s
Benchmarking parse/real_large: Collecting 30 samples in estimated 2.0010 s (722k iterations)
Benchmarking parse/real_large: Analyzing
parse/real_large        time:   [2.7475 µs 2.7658 µs 2.7916 µs]
                        thrpt:  [1.0068 GiB/s 1.0163 GiB/s 1.0230 GiB/s]
                 change:
                        time:   [−16.608% −12.349% −9.3235%] (p = 0.00 < 0.05)
                        thrpt:  [+10.282% +14.089% +19.916%]
                        Performance has improved.
Found 3 outliers among 30 measurements (10.00%)
  1 (3.33%) low mild
  1 (3.33%) high mild
  1 (3.33%) high severe
Benchmarking parse/real_medium
Benchmarking parse/real_medium: Warming up for 1.0000 s
Benchmarking parse/real_medium: Collecting 30 samples in estimated 2.0002 s (3.8M iterations)
Benchmarking parse/real_medium: Analyzing
parse/real_medium       time:   [528.71 ns 532.47 ns 536.94 ns]
                        thrpt:  [534.61 MiB/s 539.11 MiB/s 542.94 MiB/s]
                 change:
                        time:   [−6.3377% −5.5804% −4.7924%] (p = 0.00 < 0.05)
                        thrpt:  [+5.0336% +5.9102% +6.7665%]
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild
Benchmarking parse/real_small
Benchmarking parse/real_small: Warming up for 1.0000 s
Benchmarking parse/real_small: Collecting 30 samples in estimated 2.0001 s (5.1M iterations)
Benchmarking parse/real_small: Analyzing
parse/real_small        time:   [385.86 ns 387.93 ns 390.61 ns]
                        thrpt:  [441.92 MiB/s 444.97 MiB/s 447.35 MiB/s]
                 change:
                        time:   [−8.1841% −7.7783% −7.3569%] (p = 0.00 < 0.05)
                        thrpt:  [+7.9411% +8.4343% +8.9136%]
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild
Benchmarking parse/real_xlarge
Benchmarking parse/real_xlarge: Warming up for 1.0000 s
Benchmarking parse/real_xlarge: Collecting 30 samples in estimated 2.0410 s (22k iterations)
Benchmarking parse/real_xlarge: Analyzing
parse/real_xlarge       time:   [94.092 µs 94.579 µs 95.225 µs]
                        thrpt:  [1.1777 GiB/s 1.1919 GiB/s 1.1919 GiB/s]
                 change:
                        time:   [−9.0683% −8.1875% −6.9326%] (p = 0.00 < 0.05)
                        thrpt:  [+7.4490% +8.9176% +9.9726%]
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high severe
```

