### PR TITLE
chore(napi): widen napi req for rolldown 3.12.0-alpha testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ ignored = ["napi"]
 [dependencies]
 base64-simd = "0.8"
 json-escape-simd = "3"
-napi = { version = "3", optional = true }
-napi-derive = { version = "3", optional = true }
+napi = { version = ">=3.12.0-alpha.0, <4", optional = true }
+napi-derive = { version = ">=3.7.0-alpha.0, <4", optional = true }
 rustc-hash = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }


### PR DESCRIPTION
**Draft — not for merge.** Temporary patch branch consumed via rolldown's `[patch.crates-io]` so that rolldown/rolldown#10350 (tokio-free custom async runtime) can build against the published napi `3.12.0-alpha.0` / napi-derive `3.7.0-alpha.0` prerelease bundle.

Cargo's SemVer rule only lets a prerelease satisfy a comparator naming the same `major.minor.patch` with a prerelease tag, so a plain `^3` excludes `3.12.0-alpha.0`. This branch widens `oxc_sourcemap`'s optional `napi` / `napi-derive` requirement to `>=3.12.0-alpha.0, <4` / `>=3.7.0-alpha.0, <4`. Branched off the released **v8.1.2** tag; crate content is otherwise unchanged.

Kept as a draft while the napi alphas are validated in rolldown CI. Close once the napi bundle ships a normal release (or re-touch on each alpha bump).
