### PR TITLE
perf: shrink over-sized encode buffers before returning

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -15,6 +15,11 @@ pub fn encode(sourcemap: &SourceMap<'_>) -> JSONSourceMap {
         mappings: {
             let mut mappings = String::with_capacity(estimate_mappings_length(sourcemap));
             serialize_sourcemap_mappings(sourcemap, &mut mappings);
+            // The 12-bytes-per-token estimate typically leaves the buffer ~2x
+            // over-sized; give page-scale headroom back (see `consume`).
+            if mappings.capacity() - mappings.len() >= 16 * 1024 {
+                mappings.shrink_to_fit();
+            }
             mappings
         },
         source_root: sourcemap.get_source_root().map(ToString::to_string),
@@ -510,7 +515,15 @@ impl PreAllocatedString {
     }
 
     #[inline]
-    fn consume(self) -> String {
+    fn consume(mut self) -> String {
+        // The capacity estimate assumes worst-case escaping (6x), so the buffer
+        // typically ends ~4x over-sized. Callers hold the returned JSON for a
+        // long time (bundler outputs), so give the headroom back when it is
+        // page-scale; tiny buffers keep their slack (shrink would cost more
+        // than it saves).
+        if self.0.capacity() - self.0.len() >= 16 * 1024 {
+            self.0.shrink_to_fit();
+        }
         self.0
     }
 }


### PR DESCRIPTION
## Problem

`encode_to_string` sizes its buffer for worst-case JSON escaping (`6 * total_string_bytes`), so the returned `String` typically retains **~4.4x its length in capacity** — e.g. 5.3 MB held for a 1.2 MB map. The `mappings` string built by `encode()` similarly retains ~2.2x (12 bytes/token estimated vs ~5.5 actual). Bundlers hold these strings for a long time, so the slack is a real RSS cost.

## Approach

Keep the generous estimates — they preserve the zero-realloc write guarantee that the unsafe VLQ serializer's capacity accounting relies on, and they make escape-dense inputs a non-event — and instead give the headroom back with a single `shrink_to_fit` at the end, only when the excess is page-scale (≥ 16 KB). Tiny buffers keep their slack, since shrinking them costs more than it saves.

An alternative (tightening the estimates themselves) was measured and rejected: it only reaches ~1.5x retained capacity — the mappings estimate can't be tightened safely because mappings are written last, where an under-estimate triggers a whole-buffer doubling realloc — and it regresses escape-heavy inputs.

## Measurements

Retained capacity (`capacity / len` of the returned string):

| fixture | before | after |
|---|---|---|
| `to_json_string`, real_xlarge (120 KB) | 4.36x | 1.00x |
| `to_json_string`, synthesized 1.2 MB map | 4.38x | 1.00x |
| `to_json_string`, quote-dense sourcesContent | 5.49x | 1.00x |
| `to_json().mappings`, real_xlarge | 2.24x | 1.00x |
| small maps (< 16 KB excess) | unchanged | unchanged (by design) |

Speed (criterion, `serialize` group vs saved clean-main baseline, Apple Silicon):

- `serialize/real_xlarge` (33 µs, the only fixture large enough to measure reliably): **neutral** across repeated runs (−2.3% / −1.4%).
- Sub-µs fixtures report ±3–9% swings, but a control run of *unchanged code against its own baseline* shows the same swings (+3% "regressed" on real_large, −6.9% "improved" on real_small), i.e. compile-layout noise.
- A pathological all-control-character `sourcesContent` map (where the 6x estimate is correct and no shrink fires): 90.9 µs vs 90.1 µs baseline.

The large-buffer shrink is effectively free because a shrinking `realloc` at these sizes is page remapping, not a byte copy, on macOS's allocator.

## Caveat worth checking in CI

The "shrink is free" property was validated on macOS. glibc's allocator is expected to behave the same for multi-MB buffers (`M_MMAP_THRESHOLD`), but the CodSpeed run on this PR is the confirmation — hence draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)